### PR TITLE
added omitempty to APICheckDefaults to avoid encoding empty slices as…

### DIFF
--- a/types.go
+++ b/types.go
@@ -231,8 +231,8 @@ type Group struct {
 // given group.
 type APICheckDefaults struct {
 	BaseURL         string      `json:"url"`
-	Headers         []KeyValue  `json:"headers"`
-	QueryParameters []KeyValue  `json:"queryParameters"`
-	Assertions      []Assertion `json:"assertions"`
+	Headers         []KeyValue  `json:"headers,omitempty"`
+	QueryParameters []KeyValue  `json:"queryParameters,omitempty"`
+	Assertions      []Assertion `json:"assertions,omitempty"`
 	BasicAuth       BasicAuth   `json:"basicAuth,omitempty"`
 }


### PR DESCRIPTION
resolves this issue: https://github.com/checkly/terraform-provider-checkly/issues/15

we need more checking to make sure this encoding issue isn't present in other types/settings, will do this asap as well