### PR TITLE
turn api and browser checks results to a map

### DIFF
--- a/checkly_test.go
+++ b/checkly_test.go
@@ -435,6 +435,8 @@ func TestGetCheckResult(t *testing.T) {
 	startedAt, _ := time.Parse(time.RFC3339, "2020-09-02T11:19:06.283Z")
 	stoppedAt, _ := time.Parse(time.RFC3339, "2020-09-02T11:19:06.413Z")
 	createdAt, _ := time.Parse(time.RFC3339, "2020-09-02T11:19:06.681Z")
+	// Ignore api check result comparison for now
+	result.ApiCheckResult = &checkly.ApiCheckResult{}
 	expectedResult := checkly.CheckResult{
 		ID:                  "580c4e71-0109-45ba-9130-887ff01e1a7f",
 		HasErrors:           false,
@@ -485,6 +487,9 @@ func TestGetCheckResults(t *testing.T) {
 	startedAt, _ := time.Parse(time.RFC3339, "2020-09-02T11:19:06.283Z")
 	stoppedAt, _ := time.Parse(time.RFC3339, "2020-09-02T11:19:06.413Z")
 	createdAt, _ := time.Parse(time.RFC3339, "2020-09-02T11:19:06.681Z")
+	actualFirstResult := results[0]
+	// Ignore api check result comparison for now
+	actualFirstResult.ApiCheckResult = &checkly.ApiCheckResult{}
 	expectedFirstResult := checkly.CheckResult{
 		ID:                  "580c4e71-0109-45ba-9130-887ff01e1a7f",
 		HasErrors:           false,
@@ -503,7 +508,7 @@ func TestGetCheckResults(t *testing.T) {
 		IsDegraded:          false,
 		OverMaxResponseTime: false,
 	}
-	if !cmp.Equal(expectedFirstResult, results[0], nil) {
+	if !cmp.Equal(expectedFirstResult, actualFirstResult, nil) {
 		expected, _ := json.Marshal(expectedFirstResult)
 		got, _ := json.Marshal(results[0])
 		t.Errorf("Got invalid result, expected: %s, \ngot: %s", expected, got)

--- a/types.go
+++ b/types.go
@@ -260,14 +260,14 @@ type CheckResult struct {
 }
 
 // ApiCheckResult represents an API Check result
-type ApiCheckResult struct {
+type ApiCheckResult map[string]interface {
 }
 
 // BrowserCheckResult represents a Browser Check result
-type BrowserCheckResult struct {
+type BrowserCheckResult map[string]interface {
 }
 
-// CheckResultsFilter represents the parameters that can be passed while 
+// CheckResultsFilter represents the parameters that can be passed while
 // getting Check Results
 type CheckResultsFilter struct {
 	Limit       int64

--- a/types.go
+++ b/types.go
@@ -260,12 +260,10 @@ type CheckResult struct {
 }
 
 // ApiCheckResult represents an API Check result
-type ApiCheckResult map[string]interface {
-}
+type ApiCheckResult map[string]interface{}
 
 // BrowserCheckResult represents a Browser Check result
-type BrowserCheckResult map[string]interface {
-}
+type BrowserCheckResult map[string]interface{}
 
 // CheckResultsFilter represents the parameters that can be passed while
 // getting Check Results


### PR DESCRIPTION
This allow people to access the content of ApiCheckResult and BrowserCheckResult if they want check it. I left it loosely typed since it is just carrying information