### PR TITLE
fix: debug messages output wasn't working

### DIFF
--- a/examples/demo/main.go
+++ b/examples/demo/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"io"
 	"time"
 
 	"github.com/checkly/checkly-go-sdk"
@@ -181,14 +182,13 @@ func main() {
 	}
 
 	baseUrl := "https://api.checklyhq.com"
+	var debug interface{io.Writer} = nil //change nil for os.Stdout to enable dumping of API requests and responses
 	client := checkly.NewClient(
 		baseUrl,
 		apiKey,
 		nil, //custom http client, defaults to http.DefaultClient
-		nil, //io.Writer to output debug messages
+		debug, //io.Writer to output debug messages
 	)
-	// uncomment this to enable dumping of API requests and responses
-	// client.Debug = os.Stdout
 	ctx, _ := context.WithTimeout(context.Background(), time.Second*5)
 
 	group, err := client.CreateGroup(ctx, group)


### PR DESCRIPTION
Resolves #35

**Issue**: Output debug messages weren't working because debug property wasn't accessible from "client" object.
**Solution**: Created debug variable before client object initialization so we can use it as a dynamic object property, default value is "nil" but can be changed to "os.Stdout" to enable debug messages. 

<img width="798" alt="Captura de Pantalla 2021-09-22 a la(s) 13 30 13" src="https://user-images.githubusercontent.com/47372639/134384369-e9532d21-969c-4dc8-be4f-a98a3a8ff3f7.png">

 