### PR TITLE
fix: add omitempty in some AlertChannelWebhook

### DIFF
--- a/types.go
+++ b/types.go
@@ -491,12 +491,12 @@ type AlertChannelPagerduty struct {
 //AlertChannelWebhook defines a type for a webhook alert channel
 type AlertChannelWebhook struct {
 	Name            string     `json:"name"`
-	Method          string     `json:"method"`
-	Headers         []KeyValue `json:"headers"`
-	QueryParameters []KeyValue `json:"queryParameters"`
-	Template        string     `json:"template"`
 	URL             string     `json:"url"`
-	WebhookSecret   string     `json:"webhookSecret"`
+	Method          string     `json:"method,omitempty"`
+	Template        string     `json:"template,omitempty"`
+	WebhookSecret   string     `json:"webhookSecret,omitempty"`
+	Headers         []KeyValue `json:"headers,omitempty"`
+	QueryParameters []KeyValue `json:"queryParameters,omitempty"`
 }
 
 // AlertChannel represents an alert channel and its subscribed checks. The API


### PR DESCRIPTION
## Affected Components
* [ ] New Features
* [x] Bug Fixing
* [ ] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

## Notes for the Reviewer
Add `omitempty` to `AlertChannelWebhook` optional fields

- WebhookSecret
- Template
- Method
- Headers
- QueryParameters

> Resolves #41