### PR TITLE
Code improvements and remove commented code

### DIFF
--- a/checkly.go
+++ b/checkly.go
@@ -104,8 +104,7 @@ func (c *client) Update(
 	return &result, nil
 }
 
-// Delete deletes the check with the specified ID. It returns a non-nil
-// error if the request failed.
+// Delete deletes the check with the specified ID. 
 func (c *client) Delete(
 	ctx context.Context,
 	ID string,
@@ -239,8 +238,7 @@ func (c *client) UpdateGroup(
 	return &result, nil
 }
 
-// DeleteGroup deletes the check group with the specified ID. It returns a
-// non-nil error if the request failed.
+// DeleteGroup deletes the check group with the specified ID.
 func (c *client) DeleteGroup(
 	ctx context.Context,
 	ID int64,
@@ -419,7 +417,6 @@ func (c *client) UpdateSnippet(
 }
 
 // DeleteSnippet deletes the snippet with the specified ID. It returns a
-// non-nil error if the request failed.
 func (c *client) DeleteSnippet(
 	ctx context.Context,
 	ID int64,
@@ -518,8 +515,7 @@ func (c *client) UpdateEnvironmentVariable(
 	return &result, nil
 }
 
-// DeleteEnvironmentVariable deletes the environment variable with the specified ID. It returns a
-// non-nil error if the request failed.
+// DeleteEnvironmentVariable deletes the environment variable with the specified ID. 
 func (c *client) DeleteEnvironmentVariable(
 	ctx context.Context,
 	key string,
@@ -599,7 +595,6 @@ func (c *client) UpdateAlertChannel(
 }
 
 // DeleteAlertChannel deletes the alert channel with the specified ID. It returns a
-// non-nil error if the request failed.
 func (c *client) DeleteAlertChannel(
 	ctx context.Context,
 	ID int64,
@@ -638,7 +633,7 @@ func (c *client) CreateDashboard(
 		return nil, err
 	}
 	if status != http.StatusOK && status != http.StatusCreated {
-		return nil, fmt.Errorf("unexpected response status: %d, res: %q, payload: %v", status, res, string(data))
+		return nil, fmt.Errorf("unexpected response status: %d, res: %q, payload: %s", status, res, data)
 	}
 	return &result, nil
 }
@@ -664,8 +659,7 @@ func (c *client) GetDashboard(
 	return &result, nil
 }
 
-// DeleteDashboard deletes the dashboard with the specified ID. It returns a
-// non-nil error if the request failed.
+// DeleteDashboard deletes the dashboard with the specified ID. 
 func (c *client) DeleteDashboard(
 	ctx context.Context,
 	ID string,

--- a/checkly_integration_test.go
+++ b/checkly_integration_test.go
@@ -23,7 +23,7 @@ func setupClient(t *testing.T) checkly.Client {
 	}
 	apiKey := os.Getenv("CHECKLY_API_KEY")
 	if apiKey == "" {
-		t.Fatal("'CHECKLY_API_KEY' must be set for integration tests")
+		t.Error("'CHECKLY_API_KEY' must be set for integration tests")
 	}
 	return checkly.NewClient(
 		baseUrl,
@@ -39,7 +39,7 @@ func TestCreateIntegration(t *testing.T) {
 
 	gotCheck, err := client.Create(context.Background(), wantCheck)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	defer client.Delete(context.Background(), gotCheck.ID)
 	if !cmp.Equal(wantCheck, *gotCheck, ignoreCheckFields) {
@@ -51,12 +51,12 @@ func TestGetIntegration(t *testing.T) {
 	client := setupClient(t)
 	check, err := client.Create(context.Background(), wantCheck)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	defer client.Delete(context.Background(), check.ID)
 	gotCheck, err := client.Get(context.Background(), check.ID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(wantCheck, *gotCheck, ignoreCheckFields) {
 		t.Error(cmp.Diff(wantCheck, *gotCheck, ignoreCheckFields))
@@ -68,7 +68,7 @@ func TestUpdateIntegration(t *testing.T) {
 	client := setupClient(t)
 	check, err := client.Create(context.Background(), wantCheck)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	defer client.Delete(context.Background(), check.ID)
 	updatedCheck := wantCheck
@@ -87,7 +87,7 @@ func TestDeleteIntegration(t *testing.T) {
 	client := setupClient(t)
 	check, err := client.Create(context.Background(), wantCheck)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if err := client.Delete(context.Background(), check.ID); err != nil {
 		t.Error(err)
@@ -117,7 +117,7 @@ func TestCreateGroupIntegration(t *testing.T) {
 	wantGroupCopy.AlertChannelSubscriptions[0].ChannelID = ac.ID
 	gotGroup, err := client.CreateGroup(context.Background(), wantGroupCopy)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	defer client.DeleteGroup(context.Background(), gotGroup.ID)
 	// These are set by the APIs
@@ -134,7 +134,7 @@ func TestGetGroupIntegration(t *testing.T) {
 	wantGroupCopy.AlertChannelSubscriptions[0].ChannelID = ac.ID
 	group, err := client.CreateGroup(context.Background(), wantGroupCopy)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	defer client.DeleteGroup(context.Background(), group.ID)
 	gotGroup, err := client.GetGroup(context.Background(), group.ID)
@@ -155,7 +155,7 @@ func TestCreateDashboardIntegration(t *testing.T) {
 
 	gotDashboard, err := client.CreateDashboard(context.Background(), testDashboard)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	defer client.DeleteDashboard(context.Background(), gotDashboard.DashboardID)
 	if !cmp.Equal(testDashboard, *gotDashboard, ignoreDashboardFields) {
@@ -167,12 +167,12 @@ func TestGetDashboardIntegration(t *testing.T) {
 	client := setupClient(t)
 	dash, err := client.CreateDashboard(context.Background(), testDashboard)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	defer client.DeleteDashboard(context.Background(), dash.DashboardID)
 	gotDashboard, err := client.GetDashboard(context.Background(), dash.DashboardID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(testDashboard, *gotDashboard, ignoreDashboardFields) {
 		t.Error(cmp.Diff(testDashboard, *gotDashboard, ignoreDashboardFields))

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -114,13 +114,13 @@ func cannedResponseServer(
 		}
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 		validate(t, body)
 		w.WriteHeader(status)
 		data, err := os.Open(fmt.Sprintf("testdata/%s", filename))
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 		defer data.Close()
 		io.Copy(w, data)
@@ -162,7 +162,7 @@ func TestAPIError(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	_, err := client.Create(context.Background(), checkly.Check{})
 	if err == nil {
-		t.Fatal("want error when API returns 'bad request' status, got nil")
+		t.Error("want error when API returns 'bad request' status, got nil")
 	}
 	if !strings.Contains(err.Error(), "frequency") {
 		t.Errorf("want API error value to contain 'frequency', got %q", err.Error())
@@ -182,7 +182,7 @@ func TestCreate(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	gotCheck, err := client.Create(context.Background(), wantCheck)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(wantCheck, *gotCheck, ignoreCheckFields) {
 		t.Error(cmp.Diff(wantCheck, *gotCheck, ignoreCheckFields))
@@ -202,7 +202,7 @@ func TestGet(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	gotCheck, err := client.Get(context.Background(), wantCheckID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(wantCheck, *gotCheck, ignoreCheckFields) {
 		t.Error(cmp.Diff(wantCheck, *gotCheck, ignoreCheckFields))
@@ -222,7 +222,7 @@ func TestUpdate(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	gotCheck, err := client.Update(context.Background(), wantCheckID, wantCheck)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(wantCheck, *gotCheck, ignoreCheckFields) {
 		t.Error(cmp.Diff(wantCheck, *gotCheck, ignoreCheckFields))
@@ -242,7 +242,7 @@ func TestDelete(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	err := client.Delete(context.Background(), wantCheckID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -342,7 +342,7 @@ func TestCreateGroup(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	gotGroup, err := client.CreateGroup(context.Background(), wantGroup)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	ignored := cmpopts.IgnoreFields(checkly.Group{}, "ID", "AlertChannelSubscriptions")
 	if !cmp.Equal(wantGroup, *gotGroup, ignored) {
@@ -363,7 +363,7 @@ func TestGetGroup(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	gotGroup, err := client.GetGroup(context.Background(), wantGroupID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	ignored := cmpopts.IgnoreFields(checkly.Group{}, "ID", "AlertChannelSubscriptions")
 	if !cmp.Equal(wantGroup, *gotGroup, ignored) {
@@ -384,7 +384,7 @@ func TestUpdateGroup(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	gotGroup, err := client.UpdateGroup(context.Background(), wantGroupID, wantGroup)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	ignored := cmpopts.IgnoreFields(checkly.Group{}, "ID", "AlertChannelSubscriptions")
 	if !cmp.Equal(wantGroup, *gotGroup, ignored) {
@@ -405,7 +405,7 @@ func TestDeleteGroup(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	err := client.DeleteGroup(context.Background(), wantGroupID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -469,7 +469,7 @@ func TestGetCheckResults(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	results, err := client.GetCheckResults(context.Background(), wantCheckID, nil)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if len(results) != 10 {
 		t.Errorf("Expected to get 10 results got %d", len(results))
@@ -528,7 +528,7 @@ func TestGetCheckResultsWithFilters(t *testing.T) {
 		Location:    "us-east-1",
 	})
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if len(results) != 10 {
 		t.Errorf("Expected to get 10 results got %d", len(results))
@@ -553,7 +553,7 @@ func TestGetCheckResultsWithFilters2(t *testing.T) {
 		"73d29e72-6540", &checkly.CheckResultsFilter{},
 	)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if len(results) != 10 {
 		t.Errorf("Expected to get 10 results got %d", len(results))
@@ -593,7 +593,7 @@ func TestCreateSnippet(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	gotSnippet, err := client.CreateSnippet(context.Background(), testSnippet)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(testSnippet, *gotSnippet, ignoreSnippetFields) {
 		t.Error(cmp.Diff(testSnippet, *gotSnippet, ignoreSnippetFields))
@@ -613,7 +613,7 @@ func TestGetSnippet(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	gotSnippet, err := client.GetSnippet(context.Background(), testSnippet.ID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(testSnippet, *gotSnippet, ignoreSnippetFields) {
 		t.Error(cmp.Diff(testSnippet, *gotSnippet, ignoreSnippetFields))
@@ -633,7 +633,7 @@ func TestUpdateSnippet(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	gotSnippet, err := client.UpdateSnippet(context.Background(), testSnippet.ID, testSnippet)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(testSnippet, *gotSnippet, ignoreSnippetFields) {
 		t.Error(cmp.Diff(testSnippet, *gotSnippet, ignoreSnippetFields))
@@ -653,7 +653,7 @@ func TestDeleteSnippet(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	err := client.DeleteSnippet(context.Background(), testSnippet.ID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -686,7 +686,7 @@ func TestCreateEnvironmentVariable(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	result, err := client.CreateEnvironmentVariable(context.Background(), testEnvVariable)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(testEnvVariable, *result, nil) {
 		t.Error(cmp.Diff(testEnvVariable, *result, nil))
@@ -706,7 +706,7 @@ func TestGetEnvironmentVariable(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	result, err := client.GetEnvironmentVariable(context.Background(), testEnvVariable.Key)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(testEnvVariable, *result, nil) {
 		t.Error(cmp.Diff(testEnvVariable, *result, nil))
@@ -730,7 +730,7 @@ func TestUpdateEnvironmentVariable(t *testing.T) {
 		testEnvVariable,
 	)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(testEnvVariable, *result, nil) {
 		t.Error(cmp.Diff(testEnvVariable, *result, nil))
@@ -750,7 +750,7 @@ func TestDeleteEnvironmentVariable(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	err := client.DeleteEnvironmentVariable(context.Background(), testEnvVariable.Key)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -845,7 +845,7 @@ func TestCreateAlertChannel(t *testing.T) {
 	ta := getTestAlertChannelEmail()
 	ac, err := client.CreateAlertChannel(context.Background(), *ta)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(ta, ac, ignoreAlertChannelFields) {
 		t.Error(cmp.Diff(ta, ac, ignoreAlertChannelFields))
@@ -867,7 +867,7 @@ func TestGetAlertChannel(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	ac, err := client.GetAlertChannel(context.Background(), ta.ID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(ta, *ac, ignoreAlertChannelFields) {
 		t.Error(cmp.Diff(ta, *ac, ignoreAlertChannelFields))
@@ -888,7 +888,7 @@ func TestUpdateAlertChannel(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	_, err := client.UpdateAlertChannel(context.Background(), ta.ID, *ta)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -906,7 +906,7 @@ func TestDeleteAlertChannel(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	err := client.DeleteAlertChannel(context.Background(), ta.ID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -1036,7 +1036,7 @@ func TestCreateDashboard(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	gotDashboard, err := client.CreateDashboard(context.Background(), testDashboard)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(testDashboard, *gotDashboard, ignoreDashboardFields) {
 		t.Error(cmp.Diff(testDashboard, *gotDashboard, ignoreDashboardFields))
@@ -1056,7 +1056,7 @@ func TestDeleteDashboard(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	err := client.DeleteDashboard(context.Background(), testDashboard.DashboardID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -1073,7 +1073,7 @@ func TestUpdateDashboard(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	_, err := client.UpdateDashboard(context.Background(), testDashboard.DashboardID, testDashboard)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -1091,7 +1091,7 @@ func TestGetDashboard(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	ac, err := client.GetDashboard(context.Background(), testDashboard.DashboardID)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if !cmp.Equal(testDashboard, *ac, ignoreDashboardFields) {
 		t.Error(cmp.Diff(testDashboard, *ac, ignoreDashboardFields))

--- a/types.go
+++ b/types.go
@@ -28,7 +28,6 @@ type Client interface {
 	) (*Check, error)
 
 	// Delete deletes the check with the specified ID.
-	// It returns a non-nil error if the request failed.
 	Delete(
 		ctx context.Context,
 		ID string,
@@ -65,7 +64,6 @@ type Client interface {
 	) (*Group, error)
 
 	// DeleteGroup deletes the check group with the specified ID. It returns a
-	// non-nil error if the request failed.
 	DeleteGroup(
 		ctx context.Context,
 		ID int64,
@@ -109,7 +107,6 @@ type Client interface {
 	) (*Snippet, error)
 
 	// DeleteSnippet deletes the snippet with the specified ID. It returns a
-	// non-nil error if the request failed.
 	DeleteSnippet(
 		ctx context.Context,
 		ID int64,
@@ -140,7 +137,6 @@ type Client interface {
 	) (*EnvironmentVariable, error)
 
 	// DeleteEnvironmentVariable deletes the environment variable with the specified ID. It returns a
-	// non-nil error if the request failed.
 	DeleteEnvironmentVariable(
 		ctx context.Context,
 		key string,
@@ -170,7 +166,6 @@ type Client interface {
 	) (*AlertChannel, error)
 
 	// DeleteAlertChannel deletes the alert channel with the specified ID. It returns a
-	// non-nil error if the request failed.
 	DeleteAlertChannel(
 		ctx context.Context,
 		ID int64,


### PR DESCRIPTION
Resolves #46 

- Replace printf("%v", string(byteSlice)) with printf("%s", byteSlice)
- Use t.Error in test cases instead of t.Fatal (t.Fail was giving an argument syntax error)
- Change function description to avoid redundancy