### PR TITLE
feature: add skipSSL request property [sc-6270]

### DIFF
--- a/types.go
+++ b/types.go
@@ -376,6 +376,7 @@ type Request struct {
 	Method          string      `json:"method"`
 	URL             string      `json:"url"`
 	FollowRedirects bool        `json:"followRedirects"`
+	SkipSSL         bool        `json:"skipSSL"`
 	Body            string      `json:"body"`
 	BodyType        string      `json:"bodyType,omitempty"`
 	Headers         []KeyValue  `json:"headers"`


### PR DESCRIPTION
## Affected Components
* [ ] New Features
* [ ] Bug Fixing
* [X] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [X] Go code is formatted with `go fmt`

## Notes for the Reviewer
The create check API endpoint allows a new param, skipSSL for request.

> Resolves #67 