### PR TITLE
refactor: depreacate SSLCertificates and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,10 +249,6 @@ var wantGroup = checkly.Group{
 			Amount:   0,
 			Interval: 5,
 		},
-		SSLCertificates: checkly.SSLCertificates{
-			Enabled:        true,
-			AlertThreshold: 30,
-		},
 	},
 	AlertChannelSubscriptions: []checkly.Subscription{
 		{
@@ -319,7 +315,6 @@ Accept-Encoding: gzip
 "localSetupScript":"setitup","localTearDownScript":"tearitdown","alertSettings":
 {"escalationType":"RUN_BASED","runBasedEscalation":{"failedRunThreshold":1},
 "timeBasedEscalation":{"minutesFailingThreshold":5},"reminders":{"interval":5},
-"sslCertificates":{"enabled":false,"alertThreshold":30}},
 "useGlobalAlertSettings":false,"request":{"method":"GET","url":"https://example.
 com","followRedirects":false,"body":"","bodyType":"NONE","headers":[
 {"key":"X-Test","value":"foo","locked":false}],"queryParameters":[
@@ -346,11 +341,7 @@ Via: 1.1 vegur
 "sslCheck":true,"localSetupScript":"setitup","localTearDownScript":"tearitdown",
 "alertSettings":{"escalationType":"RUN_BASED","runBasedEscalation":
 {"failedRunThreshold":1},"timeBasedEscalation":{"minutesFailingThreshold":5},
-"reminders":{"interval":5,"amount":0},"sslCertificates":{"enabled":false,
-"alertThreshold":30}},"useGlobalAlertSettings":false,"request":{"method":"GET",
-"url":"https://example.com","followRedirects":false,"body":"","bodyType":"NONE",
-"headers":[{"key":"X-Test","value":"foo","locked":false}],"queryParameters":[
-{"key":"query","value":"foo","locked":false}],"assertions":[
+"reminders":{"interval":5,"amount":0},"useGlobalAlertSettings":false,"request":{"method":"GET","url":"https://example.com","followRedirects":false,"body":"","bodyType":"NONE","headers":[{"key":"X-Test","value":"foo","locked":false}],"queryParameters":[{"key":"query","value":"foo","locked":false}],"assertions":[
 {"source":"STATUS_CODE","property":"","comparison":"EQUALS","target":"200"}],
 "basicAuth":{"username":"","password":""}},"setupSnippetId":null,
 "tearDownSnippetId":null,"groupId":null,"groupOrder":null,

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -86,10 +86,6 @@ var wantCheck = checkly.Check{
 		Reminders: checkly.Reminders{
 			Interval: 5,
 		},
-		SSLCertificates: checkly.SSLCertificates{
-			Enabled:        false,
-			AlertThreshold: 30,
-		},
 	},
 	UseGlobalAlertSettings:    false,
 	DegradedResponseTime:      15000,
@@ -302,10 +298,6 @@ var wantGroup = checkly.Group{
 		Reminders: checkly.Reminders{
 			Amount:   0,
 			Interval: 5,
-		},
-		SSLCertificates: checkly.SSLCertificates{
-			Enabled:        true,
-			AlertThreshold: 30,
 		},
 	},
 	AlertChannelSubscriptions: []checkly.AlertChannelSubscription{

--- a/examples/demo/main.go
+++ b/examples/demo/main.go
@@ -23,10 +23,6 @@ var alertSettings = checkly.AlertSettings{
 	Reminders: checkly.Reminders{
 		Interval: 5,
 	},
-	SSLCertificates: checkly.SSLCertificates{
-		Enabled:        false,
-		AlertThreshold: 3,
-	},
 }
 
 var dashboard = checkly.Dashboard{
@@ -190,10 +186,6 @@ var group = checkly.Group{
 		Reminders: checkly.Reminders{
 			Amount:   0,
 			Interval: 5,
-		},
-		SSLCertificates: checkly.SSLCertificates{
-			Enabled:        true,
-			AlertThreshold: 30,
 		},
 	},
 	LocalSetupScript:    "setup-test",

--- a/testdata/CreateCheck.json
+++ b/testdata/CreateCheck.json
@@ -62,10 +62,6 @@
     "reminders": {
       "amount": 0,
       "interval": 5
-    },
-    "sslCertificates": {
-      "enabled": false,
-      "alertThreshold": 30
     }
   },
   "script": "foo",

--- a/testdata/CreateGroup.json
+++ b/testdata/CreateGroup.json
@@ -58,10 +58,6 @@
     "reminders": {
       "amount": 0,
       "interval": 5
-    },
-    "sslCertificates": {
-      "enabled": true,
-      "alertThreshold": 30
     }
   },
   "alertChannelSubscriptions": [

--- a/testdata/GetCheck.json
+++ b/testdata/GetCheck.json
@@ -62,10 +62,6 @@
     "reminders": {
       "amount": 0,
       "interval": 5
-    },
-    "sslCertificates": {
-      "enabled": false,
-      "alertThreshold": 30
     }
   },
   "script": "foo",

--- a/testdata/UpdateCheck.json
+++ b/testdata/UpdateCheck.json
@@ -62,10 +62,6 @@
     "reminders": {
       "amount": 0,
       "interval": 5
-    },
-    "sslCertificates": {
-      "enabled": false,
-      "alertThreshold": 30
     }
   },
   "script": "foo",

--- a/testdata/UpdateGroup.json
+++ b/testdata/UpdateGroup.json
@@ -37,10 +37,6 @@
       "interval": 5
     },
     "escalationType": "RUN_BASED",
-    "sslCertificates": {
-      "enabled": true,
-      "alertThreshold": 30
-    },
     "runBasedEscalation": {
       "failedRunThreshold": 1
     },

--- a/types.go
+++ b/types.go
@@ -426,7 +426,9 @@ type AlertSettings struct {
 	RunBasedEscalation  RunBasedEscalation  `json:"runBasedEscalation,omitempty"`
 	TimeBasedEscalation TimeBasedEscalation `json:"timeBasedEscalation,omitempty"`
 	Reminders           Reminders           `json:"reminders,omitempty"`
-	SSLCertificates     SSLCertificates     `json:"sslCertificates,omitempty"`
+	// Deprecated: SSLCertificates field will be removed in v2.
+	// Is not longer supported by Checkly Public API and will be ignored.
+	SSLCertificates SSLCertificates `json:"sslCertificates,omitempty"`
 }
 
 // RunBasedEscalation represents an alert escalation based on a number of failed
@@ -449,6 +451,7 @@ type Reminders struct {
 }
 
 // SSLCertificates represents alert settings for expiring SSL certificates.
+// Deprecated: SSLCertificates struct will be removed in v2.
 type SSLCertificates struct {
 	Enabled        bool `json:"enabled"`
 	AlertThreshold int  `json:"alertThreshold"`


### PR DESCRIPTION
## Affected Components
* [ ] New Features
* [ ] Bug Fixing
* [ ] Types
* [ ] Tests
* [x] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

## Notes for the Reviewer
- Deprecate `SSLCertificates` property/struct, update docs and test cases

> Resolves #70 