### PR TITLE
chore: change create check endpoint for new one

### DIFF
--- a/checkly_test.go
+++ b/checkly_test.go
@@ -248,6 +248,83 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestCreateCheck(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodPost,
+		"/v1/checks?autoAssignAlerts=false",
+		validateCheck,
+		http.StatusCreated,
+		"CreateCheck.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	gotCheck, err := client.CreateCheck(context.Background(), wantCheck)
+	if err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(wantCheck, *gotCheck, ignoreCheckFields) {
+		t.Error(cmp.Diff(wantCheck, *gotCheck, ignoreCheckFields))
+	}
+}
+
+func TestGetCheck(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodGet,
+		fmt.Sprintf("/v1/checks/%s", wantCheckID),
+		validateEmptyBody,
+		http.StatusOK,
+		"GetCheck.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	gotCheck, err := client.GetCheck(context.Background(), wantCheckID)
+	if err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(wantCheck, *gotCheck, ignoreCheckFields) {
+		t.Error(cmp.Diff(wantCheck, *gotCheck, ignoreCheckFields))
+	}
+}
+
+func TestUpdateCheck(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodPut,
+		fmt.Sprintf("/v1/checks/%s?autoAssignAlerts=false", wantCheckID),
+		validateCheck,
+		http.StatusOK,
+		"UpdateCheck.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	gotCheck, err := client.UpdateCheck(context.Background(), wantCheckID, wantCheck)
+	if err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(wantCheck, *gotCheck, ignoreCheckFields) {
+		t.Error(cmp.Diff(wantCheck, *gotCheck, ignoreCheckFields))
+	}
+}
+
+func TestDeleteCheck(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodDelete,
+		fmt.Sprintf("/v1/checks/%s", wantCheckID),
+		validateEmptyBody,
+		http.StatusNoContent,
+		"Empty.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	err := client.DeleteCheck(context.Background(), wantCheckID)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 var wantGroupID int64 = 135
 
 var wantGroup = checkly.Group{

--- a/types.go
+++ b/types.go
@@ -14,6 +14,9 @@ import (
 type Client interface {
 	// Create creates a new check with the specified details.
 	// It returns the newly-created check, or an error.
+	//
+	// Deprecated: this type would be removed in future versions,
+	// use CreateCheck instead.
 	Create(
 		ctx context.Context,
 		check Check,
@@ -21,6 +24,9 @@ type Client interface {
 
 	// Update updates an existing check with the specified details.
 	// It returns the updated check, or an error.
+	//
+	// Deprecated: this type would be removed in future versions,
+	// use UpdateCheck instead.
 	Update(
 		ctx context.Context,
 		ID string,
@@ -28,6 +34,9 @@ type Client interface {
 	) (*Check, error)
 
 	// Delete deletes the check with the specified ID.
+	//
+	// Deprecated: this type would be removed in future versions,
+	// use DeleteCheck instead.
 	Delete(
 		ctx context.Context,
 		ID string,
@@ -35,7 +44,38 @@ type Client interface {
 
 	// Get takes the ID of an existing check, and returns the check parameters,
 	// or an error.
+	//
+	// Deprecated: this type would be removed in future versions,
+	// use GetCheck instead.
 	Get(
+		ctx context.Context,
+		ID string,
+	) (*Check, error)
+
+	// Create creates a new check with the specified details.
+	// It returns the newly-created check, or an error.
+	CreateCheck(
+		ctx context.Context,
+		check Check,
+	) (*Check, error)
+
+	// Update updates an existing check with the specified details.
+	// It returns the updated check, or an error.
+	UpdateCheck(
+		ctx context.Context,
+		ID string,
+		check Check,
+	) (*Check, error)
+
+	// Delete deletes the check with the specified ID.
+	DeleteCheck(
+		ctx context.Context,
+		ID string,
+	) error
+
+	// Get takes the ID of an existing check, and returns the check parameters,
+	// or an error.
+	GetCheck(
 		ctx context.Context,
 		ID string,
 	) (*Check, error)


### PR DESCRIPTION
Resolves #71 

## Affected Components
* [ ] New Features
* [ ] Bug Fixing
* [X] Types
* [X] Tests
* [ ] Docs
* [ ] Other

- New CURD types with more verbose names 
- Flag old methods as deprecated
- Change CreateCheck function to use new endpoints (checks/api and checks/browser)
- Add tests for new methods
