### PR TITLE
refactor: deprecate sslCertificates from AlertSettings and sslChecks from Checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ check := checkly.Check{
 	Muted:                false,
 	ShouldFail:           false,
 	DoubleCheck:          false,
-	SSLCheck:             true,
 	LocalSetupScript:     "",
 	LocalTearDownScript:  "",
 	Locations: []string{
@@ -124,7 +123,6 @@ check := checkly.Check{
 	Muted:         false,
 	ShouldFail:    false,
 	DoubleCheck:   false,
-	SSLCheck:      true,
 	Locations:     []string{"eu-west-1"},
 	AlertSettings: alertSettings,
 	Script: `const assert = require("chai").assert;

--- a/README.md
+++ b/README.md
@@ -249,10 +249,6 @@ var wantGroup = checkly.Group{
 			Amount:   0,
 			Interval: 5,
 		},
-		SSLCertificates: checkly.SSLCertificates{
-			Enabled:        true,
-			AlertThreshold: 30,
-		},
 	},
 	AlertChannelSubscriptions: []checkly.Subscription{
 		{
@@ -319,7 +315,6 @@ Accept-Encoding: gzip
 "localSetupScript":"setitup","localTearDownScript":"tearitdown","alertSettings":
 {"escalationType":"RUN_BASED","runBasedEscalation":{"failedRunThreshold":1},
 "timeBasedEscalation":{"minutesFailingThreshold":5},"reminders":{"interval":5},
-"sslCertificates":{"enabled":false,"alertThreshold":30}},
 "useGlobalAlertSettings":false,"request":{"method":"GET","url":"https://example.
 com","followRedirects":false,"body":"","bodyType":"NONE","headers":[
 {"key":"X-Test","value":"foo","locked":false}],"queryParameters":[
@@ -346,8 +341,7 @@ Via: 1.1 vegur
 "sslCheck":true,"localSetupScript":"setitup","localTearDownScript":"tearitdown",
 "alertSettings":{"escalationType":"RUN_BASED","runBasedEscalation":
 {"failedRunThreshold":1},"timeBasedEscalation":{"minutesFailingThreshold":5},
-"reminders":{"interval":5,"amount":0},"sslCertificates":{"enabled":false,
-"alertThreshold":30}},"useGlobalAlertSettings":false,"request":{"method":"GET",
+"reminders":{"interval":5,"amount":0},"useGlobalAlertSettings":false,"request":{"method":"GET",
 "url":"https://example.com","followRedirects":false,"body":"","bodyType":"NONE",
 "headers":[{"key":"X-Test","value":"foo","locked":false}],"queryParameters":[
 {"key":"query","value":"foo","locked":false}],"assertions":[

--- a/checkly.go
+++ b/checkly.go
@@ -59,7 +59,7 @@ func (c *client) SetChecklySource(source string) {
 // Create creates a new check with the specified details. It returns the
 // newly-created check, or an error.
 //
-// Deprecated: this type would be removed in future versions,
+// Deprecated: this method would be removed in future versions,
 // use CreateCheck instead.
 func (c *client) Create(
 	ctx context.Context,
@@ -91,7 +91,7 @@ func (c *client) Create(
 // Update updates an existing check with the specified details. It returns the
 // updated check, or an error.
 //
-// Deprecated: this type would be removed in future versions,
+// Deprecated: this method would be removed in future versions,
 // use UpdateCheck instead.
 func (c *client) Update(
 	ctx context.Context,
@@ -123,7 +123,7 @@ func (c *client) Update(
 
 // Delete deletes the check with the specified ID.
 //
-// Deprecated: this type would be removed in future versions,
+// Deprecated: this method would be removed in future versions,
 // use DeleteCheck instead.
 func (c *client) Delete(
 	ctx context.Context,
@@ -147,7 +147,7 @@ func (c *client) Delete(
 // Get takes the ID of an existing check, and returns the check parameters, or
 // an error.
 //
-// Deprecated: this type would be removed in future versions,
+// Deprecated: this method would be removed in future versions,
 // use GetCheck instead.
 func (c *client) Get(
 	ctx context.Context,
@@ -1074,29 +1074,6 @@ func (c *client) DeleteTriggerGroup(
 		return fmt.Errorf("unexpected response status %d: %q", status, res)
 	}
 	return nil
-}
-
-func (c *client) GetLocations(
-	ctx context.Context,
-) (*[]Location, error) {
-	status, res, err := c.apiCall(
-		ctx,
-		http.MethodGet,
-		fmt.Sprintf("locations"),
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-	if status != http.StatusOK {
-		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
-	}
-	locations := &[]Location{}
-	err = json.NewDecoder(strings.NewReader(res)).Decode(&locations)
-	if err != nil {
-		return nil, fmt.Errorf("decoding error for data %q: %v", res, err)
-	}
-	return locations, nil
 }
 
 func payloadFromAlertChannel(ac AlertChannel) map[string]interface{} {

--- a/checkly.go
+++ b/checkly.go
@@ -1076,6 +1076,29 @@ func (c *client) DeleteTriggerGroup(
 	return nil
 }
 
+func (c *client) GetLocations(
+	ctx context.Context,
+) (*[]Location, error) {
+	status, res, err := c.apiCall(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("locations"),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	locations := &[]Location{}
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&locations)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %q: %v", res, err)
+	}
+	return locations, nil
+}
+
 func payloadFromAlertChannel(ac AlertChannel) map[string]interface{} {
 	payload := map[string]interface{}{
 		"id":     ac.ID,

--- a/checkly_integration_test.go
+++ b/checkly_integration_test.go
@@ -121,7 +121,7 @@ func TestCreateGroupIntegration(t *testing.T) {
 	}
 	defer client.DeleteGroup(context.Background(), gotGroup.ID)
 	// These are set by the APIs
-	ignored := cmpopts.IgnoreFields(checkly.Group{}, "ID", "AlertChannelSubscriptions")
+	ignored := cmpopts.IgnoreFields(checkly.Group{}, "ID", "AlertChannelSubscriptions", "AlertSettings.SSLCertificates")
 	if !cmp.Equal(wantGroupCopy, *gotGroup, ignored) {
 		t.Error(cmp.Diff(wantGroupCopy, *gotGroup, ignored))
 	}

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -494,7 +494,7 @@ func TestGetCheckResult(t *testing.T) {
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
 	result, err := client.GetCheckResult(context.Background(), wantCheckID, resultID)
 	if err != nil {
-		t.Errorf("Expected no errors, got %w", err)
+		t.Errorf("Expected no errors, got %v", err)
 	}
 	startedAt, _ := time.Parse(time.RFC3339, "2020-09-02T11:19:06.283Z")
 	stoppedAt, _ := time.Parse(time.RFC3339, "2020-09-02T11:19:06.413Z")

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -30,7 +30,6 @@ var wantCheck = checkly.Check{
 	Activated:   true,
 	Muted:       false,
 	DoubleCheck: true,
-	SSLCheck:    true,
 	ShouldFail:  false,
 	Locations:   []string{"eu-west-1"},
 	Request: checkly.Request{

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -145,7 +145,7 @@ func validateEmptyBody(t *testing.T, body []byte) {
 func validateAnything(*testing.T, []byte) {
 }
 
-var ignoreCheckFields = cmpopts.IgnoreFields(checkly.Check{}, "ID", "AlertChannelSubscriptions", "FrequencyOffset")
+var ignoreCheckFields = cmpopts.IgnoreFields(checkly.Check{}, "ID", "AlertChannelSubscriptions", "FrequencyOffset", "AlertSettings.SSLCertificates")
 
 func TestAPIError(t *testing.T) {
 	t.Parallel()
@@ -398,7 +398,7 @@ func validateGroup(t *testing.T, body []byte) {
 	}
 }
 
-var ignoreGroupFields = cmpopts.IgnoreFields(checkly.Group{}, "ID")
+var ignoreGroupFields = cmpopts.IgnoreFields(checkly.Group{}, "ID", "AlertSettings.SSLCertificates")
 
 func TestCreateGroup(t *testing.T) {
 	t.Parallel()

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -86,10 +86,6 @@ var wantCheck = checkly.Check{
 		Reminders: checkly.Reminders{
 			Interval: 5,
 		},
-		SSLCertificates: checkly.SSLCertificates{
-			Enabled:        false,
-			AlertThreshold: 30,
-		},
 	},
 	UseGlobalAlertSettings:    false,
 	DegradedResponseTime:      15000,
@@ -379,10 +375,6 @@ var wantGroup = checkly.Group{
 		Reminders: checkly.Reminders{
 			Amount:   0,
 			Interval: 5,
-		},
-		SSLCertificates: checkly.SSLCertificates{
-			Enabled:        true,
-			AlertThreshold: 30,
 		},
 	},
 	AlertChannelSubscriptions: []checkly.AlertChannelSubscription{

--- a/demo/main.go
+++ b/demo/main.go
@@ -23,10 +23,6 @@ var alertSettings = checkly.AlertSettings{
 	Reminders: checkly.Reminders{
 		Interval: 5,
 	},
-	SSLCertificates: checkly.SSLCertificates{
-		Enabled:        false,
-		AlertThreshold: 3,
-	},
 }
 
 var dashboard = checkly.Dashboard{
@@ -190,10 +186,6 @@ var group = checkly.Group{
 		Reminders: checkly.Reminders{
 			Amount:   0,
 			Interval: 5,
-		},
-		SSLCertificates: checkly.SSLCertificates{
-			Enabled:        true,
-			AlertThreshold: 30,
 		},
 	},
 	LocalSetupScript:    "setup-test",

--- a/demo/main.go
+++ b/demo/main.go
@@ -61,7 +61,6 @@ var apiCheck = checkly.Check{
 	Muted:                false,
 	ShouldFail:           false,
 	DoubleCheck:          false,
-	SSLCheck:             true,
 	LocalSetupScript:     "",
 	LocalTearDownScript:  "",
 	Locations: []string{

--- a/fixtures/CreateCheck.json
+++ b/fixtures/CreateCheck.json
@@ -62,10 +62,6 @@
     "reminders": {
       "amount": 0,
       "interval": 5
-    },
-    "sslCertificates": {
-      "enabled": false,
-      "alertThreshold": 30
     }
   },
   "script": "foo",

--- a/fixtures/CreateCheck.json
+++ b/fixtures/CreateCheck.json
@@ -73,8 +73,6 @@
   "created_at": "2019-05-10T11:14:14.573Z",
   "id": "73d29e72-6540-4bb5-967e-e07fa2c9465e",
   "frequencyOffset": 84,
-  "sslCheck": true,
-  "sslCheckDomain": "example.com",
   "degradedResponseTime": 15000,
   "maxResponseTime": 30000
 }

--- a/fixtures/CreateGroup.json
+++ b/fixtures/CreateGroup.json
@@ -58,10 +58,6 @@
     "reminders": {
       "amount": 0,
       "interval": 5
-    },
-    "sslCertificates": {
-      "enabled": true,
-      "alertThreshold": 30
     }
   },
   "alertChannelSubscriptions": [

--- a/fixtures/GetCheck.json
+++ b/fixtures/GetCheck.json
@@ -62,10 +62,6 @@
     "reminders": {
       "amount": 0,
       "interval": 5
-    },
-    "sslCertificates": {
-      "enabled": false,
-      "alertThreshold": 30
     }
   },
   "script": "foo",

--- a/fixtures/GetCheck.json
+++ b/fixtures/GetCheck.json
@@ -73,8 +73,6 @@
   "created_at": "2019-05-10T11:14:14.573Z",
   "id": "73d29e72-6540-4bb5-967e-e07fa2c9465e",
   "frequencyOffset": 84,
-  "sslCheck": true,
-  "sslCheckDomain": "example.com",
   "degradedResponseTime": 15000,
   "maxResponseTime": 30000
 }

--- a/fixtures/UpdateCheck.json
+++ b/fixtures/UpdateCheck.json
@@ -62,10 +62,6 @@
     "reminders": {
       "amount": 0,
       "interval": 5
-    },
-    "sslCertificates": {
-      "enabled": false,
-      "alertThreshold": 30
     }
   },
   "script": "foo",

--- a/fixtures/UpdateCheck.json
+++ b/fixtures/UpdateCheck.json
@@ -73,8 +73,6 @@
   "created_at": "2019-05-10T11:14:14.573Z",
   "id": "73d29e72-6540-4bb5-967e-e07fa2c9465e",
   "frequencyOffset": 84,
-  "sslCheck": true,
-  "sslCheckDomain": "example.com",
   "degradedResponseTime": 15000,
   "maxResponseTime": 30000
 }

--- a/fixtures/UpdateGroup.json
+++ b/fixtures/UpdateGroup.json
@@ -37,10 +37,6 @@
       "interval": 5
     },
     "escalationType": "RUN_BASED",
-    "sslCertificates": {
-      "enabled": true,
-      "alertThreshold": 30
-    },
     "runBasedEscalation": {
       "failedRunThreshold": 1
     },

--- a/types.go
+++ b/types.go
@@ -397,7 +397,6 @@ type Check struct {
 	EnvironmentVariables      []EnvironmentVariable      `json:"environmentVariables"`
 	DoubleCheck               bool                       `json:"doubleCheck"`
 	Tags                      []string                   `json:"tags,omitempty"`
-	SSLCheck                  bool                       `json:"sslCheck"`
 	SetupSnippetID            int64                      `json:"setupSnippetId,omitempty"`
 	TearDownSnippetID         int64                      `json:"tearDownSnippetId,omitempty"`
 	LocalSetupScript          string                     `json:"localSetupScript,omitempty"`
@@ -409,6 +408,9 @@ type Check struct {
 	GroupOrder                int                        `json:"groupOrder,omitempty"`
 	AlertChannelSubscriptions []AlertChannelSubscription `json:"alertChannelSubscriptions,omitempty"`
 	RuntimeID                 *string                    `json:"runtimeId"`
+
+	// Deprecated: this property will be removed in future versions.
+	SSLCheck bool `json:"sslCheck"`
 }
 
 // Request represents the parameters for the request made by the check.

--- a/types.go
+++ b/types.go
@@ -496,8 +496,8 @@ type Reminders struct {
 // Deprecated: this type will be removed in future versions.
 // SSLCertificates represents alert settings for expiring SSL certificates.
 type SSLCertificates struct {
-	Enabled        bool `json:"enabled"`
-	AlertThreshold int  `json:"alertThreshold"`
+	Enabled        bool `json:"enabled,omitempty"`
+	AlertThreshold int  `json:"alertThreshold,omitempty"`
 }
 
 // Group represents a check group.

--- a/types.go
+++ b/types.go
@@ -299,6 +299,10 @@ type Client interface {
 		groupID int64,
 	) error
 
+	GetLocations(
+		ctx context.Context,
+	) (*[]Location, error)
+
 	// SetAccountId sets ID on a client which is required when using User API keys.
 	SetAccountId(ID string)
 
@@ -466,7 +470,8 @@ type AlertSettings struct {
 	RunBasedEscalation  RunBasedEscalation  `json:"runBasedEscalation,omitempty"`
 	TimeBasedEscalation TimeBasedEscalation `json:"timeBasedEscalation,omitempty"`
 	Reminders           Reminders           `json:"reminders,omitempty"`
-	SSLCertificates     SSLCertificates     `json:"sslCertificates,omitempty"`
+	// Deprecated: this property will be removed in future versions.
+	SSLCertificates SSLCertificates `json:"sslCertificates,omitempty"`
 }
 
 // RunBasedEscalation represents an alert escalation based on a number of failed
@@ -488,6 +493,7 @@ type Reminders struct {
 	Interval int `json:"interval,omitempty"`
 }
 
+// Deprecated: this type will be removed in future versions.
 // SSLCertificates represents alert settings for expiring SSL certificates.
 type SSLCertificates struct {
 	Enabled        bool `json:"enabled"`
@@ -701,6 +707,11 @@ type TriggerGroup struct {
 	CreatedAt string `json:"created_at"`
 	CalledAt  string `json:"called_at"`
 	UpdatedAt string `json:"updated_at"`
+}
+
+type Location struct {
+	Name   string `json:"name"`
+	Region string `json:"region"`
 }
 
 //SetConfig sets config of alert channel based on it's type

--- a/types.go
+++ b/types.go
@@ -15,7 +15,7 @@ type Client interface {
 	// Create creates a new check with the specified details.
 	// It returns the newly-created check, or an error.
 	//
-	// Deprecated: this type would be removed in future versions,
+	// Deprecated: method type would be removed in future versions,
 	// use CreateCheck instead.
 	Create(
 		ctx context.Context,
@@ -25,7 +25,7 @@ type Client interface {
 	// Update updates an existing check with the specified details.
 	// It returns the updated check, or an error.
 	//
-	// Deprecated: this type would be removed in future versions,
+	// Deprecated: this method would be removed in future versions,
 	// use UpdateCheck instead.
 	Update(
 		ctx context.Context,
@@ -35,7 +35,7 @@ type Client interface {
 
 	// Delete deletes the check with the specified ID.
 	//
-	// Deprecated: this type would be removed in future versions,
+	// Deprecated: this method would be removed in future versions,
 	// use DeleteCheck instead.
 	Delete(
 		ctx context.Context,
@@ -45,7 +45,7 @@ type Client interface {
 	// Get takes the ID of an existing check, and returns the check parameters,
 	// or an error.
 	//
-	// Deprecated: this type would be removed in future versions,
+	// Deprecated: this method would be removed in future versions,
 	// use GetCheck instead.
 	Get(
 		ctx context.Context,
@@ -298,10 +298,6 @@ type Client interface {
 		ctx context.Context,
 		groupID int64,
 	) error
-
-	GetLocations(
-		ctx context.Context,
-	) (*[]Location, error)
 
 	// SetAccountId sets ID on a client which is required when using User API keys.
 	SetAccountId(ID string)


### PR DESCRIPTION
## Affected Components
* [ ] New Features
* [ ] Bug Fixing
* [x] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

## Notes for the Reviewer
Depreacete `sslCertificates` property from `AlertSettings` and `SSLCertificates` type.

> Resolves https://github.com/checkly/checkly-go-sdk/issues/70
> Resolves https://github.com/checkly/checkly-go-sdk/issues/85