### PR TITLE
fix: add `omitempty` to env var key

### DIFF
--- a/types.go
+++ b/types.go
@@ -457,7 +457,7 @@ type KeyValue struct {
 // EnvironmentVariable represents a key-value pair for setting environment
 // values during check execution.
 type EnvironmentVariable struct {
-	Key    string `json:"key"`
+	Key    string `json:"key,omitempty"`
 	Value  string `json:"value"`
 	Locked bool   `json:"locked"`
 }


### PR DESCRIPTION
## Affected Components
* [ ] New Features
* [x] Bug Fixing
* [ ] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

## Notes for the Reviewer
Add `omitempty` to env var key.

> Resolves #89 