### PR TITLE
feat: add webhook_type field to alert channels

### DIFF
--- a/checkly_test.go
+++ b/checkly_test.go
@@ -1096,7 +1096,7 @@ var testDashboard = checkly.Dashboard{
 	UseTagsAndOperator: true,
 }
 
-var ignoreDashboardFields = cmpopts.IgnoreFields(checkly.Dashboard{}, "DashboardID")
+var ignoreDashboardFields = cmpopts.IgnoreFields(checkly.Dashboard{}, "DashboardID", "CreatedAt", "ID")
 
 func TestCreateDashboard(t *testing.T) {
 	t.Parallel()

--- a/types.go
+++ b/types.go
@@ -673,6 +673,7 @@ type AlertChannelPagerduty struct {
 type AlertChannelWebhook struct {
 	Name            string     `json:"name"`
 	URL             string     `json:"url"`
+	WebhookType     string     `json:"webhookType,omitempty"`
 	Method          string     `json:"method,omitempty"`
 	Template        string     `json:"template,omitempty"`
 	WebhookSecret   string     `json:"webhookSecret,omitempty"`


### PR DESCRIPTION
## Affected Components
* [] New Features
* [ ] Bug Fixing
* [x] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Add missing `webhook_type` field to alert channels.
