### PR TITLE
feat: support private dashboard creation

### DIFF
--- a/types.go
+++ b/types.go
@@ -502,7 +502,7 @@ type PrivateLocationKey struct {
 	UpdatedAt string `json:"updated_at"`
 }
 
-// DashboardKey represents the keys that the private location has.
+// DashboardKey represents the keys that the dashboard has.
 type DashboardKey struct {
 	Id        string `json:"id"`
 	MaskedKey string `json:"maskedKey"`

--- a/types.go
+++ b/types.go
@@ -502,6 +502,15 @@ type PrivateLocationKey struct {
 	UpdatedAt string `json:"updated_at"`
 }
 
+// DashboardKey represents the keys that the private location has.
+type DashboardKey struct {
+	Id        string `json:"id"`
+	MaskedKey string `json:"maskedKey"`
+	RawKey    string `json:"rawKey"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
 // AlertSettings represents an alert configuration.
 type AlertSettings struct {
 	EscalationType      string              `json:"escalationType,omitempty"`
@@ -703,25 +712,27 @@ type AlertChannel struct {
 
 // Dashboard defines a type for a dashboard.
 type Dashboard struct {
-	ID                 int64    `json:"id,omitempty"`
-	DashboardID        string   `json:"dashboardId,omitempty"`
-	CustomUrl          string   `json:"customUrl"`
-	CustomDomain       string   `json:"customDomain,omitempty"`
-	Logo               string   `json:"logo,omitempty"`
-	Link               string   `json:"link,omitempty"`
-	Description        string   `json:"description,omitempty"`
-	Favicon            string   `json:"favicon,omitempty"`
-	Header             string   `json:"header,omitempty"`
-	Width              string   `json:"width,omitempty"`
-	RefreshRate        int      `json:"refreshRate"`
-	ChecksPerPage      int      `json:"checksPerPage,omitempty"`
-	PaginationRate     int      `json:"paginationRate"`
-	Paginate           bool     `json:"paginate"`
-	Tags               []string `json:"tags,omitempty"`
-	HideTags           bool     `json:"hideTags,omitempty"`
-	UseTagsAndOperator bool     `json:"useTagsAndOperator,omitempty"`
-	CreatedAt          string   `json:"created_at"`
-	UpdatedAt          string   `json:"updated_at"`
+	ID                 int64          `json:"id,omitempty"`
+	DashboardID        string         `json:"dashboardId,omitempty"`
+	CustomUrl          string         `json:"customUrl"`
+	CustomDomain       string         `json:"customDomain,omitempty"`
+	IsPrivate          bool           `json:"isPrivate,omitempty"`
+	Logo               string         `json:"logo,omitempty"`
+	Link               string         `json:"link,omitempty"`
+	Description        string         `json:"description,omitempty"`
+	Favicon            string         `json:"favicon,omitempty"`
+	Header             string         `json:"header,omitempty"`
+	Width              string         `json:"width,omitempty"`
+	RefreshRate        int            `json:"refreshRate"`
+	ChecksPerPage      int            `json:"checksPerPage,omitempty"`
+	PaginationRate     int            `json:"paginationRate"`
+	Paginate           bool           `json:"paginate"`
+	Tags               []string       `json:"tags,omitempty"`
+	HideTags           bool           `json:"hideTags,omitempty"`
+	UseTagsAndOperator bool           `json:"useTagsAndOperator,omitempty"`
+	CreatedAt          string         `json:"created_at"`
+	UpdatedAt          string         `json:"updated_at"`
+	Keys               []DashboardKey `json:"keys,omitempty"`
 }
 
 // MaintenanceWindow defines a type for a maintenance window.


### PR DESCRIPTION
## Affected Components
* [ ] New Features
* [ ] Bug Fixing
* [X] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [X] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Add isPrivate and Keys property to Dashboard type, this allows user to receive the password when creating a private dashboard using go SDK. 

Testing steps:
1) On demo/main.go set isPrivate property to true in "dashboard" variable
2) On demo/main.go add a function that creates the dashboard, for example:
```
 dashboard, err := client.CreateDashboard(ctx, dashboard)
  if err != nil {
  	log.Fatalf("creating dashboard: %v", err)
  }
  fmt.Printf("New private dashboard with password %s\n", dashboard.Keys[0].RawKey)
```
3) In /demo run `go run main.go`
4) On the terminal you will see the output with the password