### PR TITLE
chore: add sslCheckDomain property [sc-0]

### DIFF
--- a/checkly_test.go
+++ b/checkly_test.go
@@ -72,6 +72,7 @@ var wantCheck = checkly.Check{
 		"foo",
 		"bar",
 	},
+	SSLCheckDomain:      "example.com",
 	LocalSetupScript:    "setitup",
 	LocalTearDownScript: "tearitdown",
 	AlertSettings: checkly.AlertSettings{
@@ -144,7 +145,9 @@ func validateEmptyBody(t *testing.T, body []byte) {
 func validateAnything(*testing.T, []byte) {
 }
 
-var ignoreCheckFields = cmpopts.IgnoreFields(checkly.Check{}, "ID", "AlertChannelSubscriptions", "FrequencyOffset", "AlertSettings.SSLCertificates", "PrivateLocations")
+// TODO: adjust wantCheck to test multiple SSLCheckDomain value and remove it from this list
+var ignoreCheckFields = cmpopts.IgnoreFields(checkly.Check{}, "ID", "AlertChannelSubscriptions", "FrequencyOffset",
+	"AlertSettings.SSLCertificates", "PrivateLocations", "SSLCheckDomain")
 
 func TestAPIError(t *testing.T) {
 	t.Parallel()

--- a/demo/main.go
+++ b/demo/main.go
@@ -107,16 +107,17 @@ var apiCheck = checkly.Check{
 }
 
 var browserCheck = checkly.Check{
-	Name:          "My Browser Check",
-	Type:          checkly.TypeBrowser,
-	Frequency:     10,
-	Activated:     true,
-	Muted:         false,
-	ShouldFail:    false,
-	DoubleCheck:   false,
-	SSLCheck:      true,
-	Locations:     []string{"eu-west-1"},
-	AlertSettings: alertSettings,
+	Name:           "My Browser Check",
+	Type:           checkly.TypeBrowser,
+	Frequency:      10,
+	Activated:      true,
+	Muted:          false,
+	ShouldFail:     false,
+	DoubleCheck:    false,
+	SSLCheck:       true,
+	SSLCheckDomain: "www.acme.com",
+	Locations:    []string{"eu-west-1"},
+	AlertSettings:  alertSettings,
 	Script: `const assert = require("chai").assert;
   const puppeteer = require("puppeteer");
 

--- a/types.go
+++ b/types.go
@@ -446,6 +446,7 @@ type Check struct {
 	EnvironmentVariables      []EnvironmentVariable      `json:"environmentVariables"`
 	DoubleCheck               bool                       `json:"doubleCheck"`
 	Tags                      []string                   `json:"tags,omitempty"`
+	SSLCheckDomain            string                     `json:"sslCheckDomain,omitempty"`
 	SetupSnippetID            int64                      `json:"setupSnippetId,omitempty"`
 	TearDownSnippetID         int64                      `json:"tearDownSnippetId,omitempty"`
 	LocalSetupScript          string                     `json:"localSetupScript,omitempty"`

--- a/types.go
+++ b/types.go
@@ -446,7 +446,7 @@ type Check struct {
 	EnvironmentVariables      []EnvironmentVariable      `json:"environmentVariables"`
 	DoubleCheck               bool                       `json:"doubleCheck"`
 	Tags                      []string                   `json:"tags,omitempty"`
-	SSLCheckDomain            string                     `json:"sslCheckDomain,omitempty"`
+	SSLCheckDomain            string                     `json:"sslCheckDomain"`
 	SetupSnippetID            int64                      `json:"setupSnippetId,omitempty"`
 	TearDownSnippetID         int64                      `json:"tearDownSnippetId,omitempty"`
 	LocalSetupScript          string                     `json:"localSetupScript,omitempty"`


### PR DESCRIPTION
## Affected Components
* [ ] New Features
* [ ] Bug Fixing
* [x] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
Following what was asked in this [thread](https://checklyhq.slack.com/archives/C024ZAJ938S/p1690276802718249) and this [issue](https://github.com/checkly/terraform-provider-checkly/issues/263), this PRs adds the `SSLCheckDomain` property into the `Check` type.
Note that `SSLCheckDomain` is ignored in wanted check output when running test. That's because, if the the property is empty, the value is generated in the backend. We can adjust test's `wantCheck` in a new PR.
<!-- Anything the reviewer should pay extra attention to. -->

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->