### PR TITLE
feat: add support for RetryStrategy

### DIFF
--- a/types.go
+++ b/types.go
@@ -444,7 +444,6 @@ type Check struct {
 	MaxResponseTime           int                        `json:"maxResponseTime"`
 	Script                    string                     `json:"script,omitempty"`
 	EnvironmentVariables      []EnvironmentVariable      `json:"environmentVariables"`
-	DoubleCheck               bool                       `json:"doubleCheck"`
 	Tags                      []string                   `json:"tags,omitempty"`
 	SSLCheckDomain            string                     `json:"sslCheckDomain"`
 	SetupSnippetID            int64                      `json:"setupSnippetId,omitempty"`
@@ -462,11 +461,14 @@ type Check struct {
 	UpdatedAt                 time.Time                  `json:"updatedAt"`
 
 	// Pointers
-	PrivateLocations *[]string `json:"privateLocations"`
-	RuntimeID        *string   `json:"runtimeId"`
+	PrivateLocations *[]string      `json:"privateLocations"`
+	RuntimeID        *string        `json:"runtimeId"`
+	RetryStrategy    *RetryStrategy `json:"retryStrategy,omitempty"`
 
 	// Deprecated: this property will be removed in future versions.
 	SSLCheck bool `json:"sslCheck"`
+	// Deprecated: this property will be removed in future versions. Please use RetryStrategy instead.
+	DoubleCheck bool `json:"doubleCheck"`
 }
 
 type HeartbeatCheck struct {
@@ -595,6 +597,14 @@ type SSLCertificates struct {
 	AlertThreshold int  `json:"alertThreshold,omitempty"`
 }
 
+type RetryStrategy struct {
+	Type               string `json:"type"`
+	BaseBackoffSeconds int    `json:"baseBackoffSeconds"`
+	MaxAttempts        int    `json:"maxAttempts"`
+	MaxDurationSeconds int    `json:"maxDurationSeconds"`
+	SameRegion         bool   `json:"sameRegion"`
+}
+
 // Group represents a check group.
 type Group struct {
 	ID                        int64                      `json:"id,omitempty"`
@@ -606,7 +616,6 @@ type Group struct {
 	Concurrency               int                        `json:"concurrency"`
 	APICheckDefaults          APICheckDefaults           `json:"apiCheckDefaults"`
 	EnvironmentVariables      []EnvironmentVariable      `json:"environmentVariables"`
-	DoubleCheck               bool                       `json:"doubleCheck"`
 	UseGlobalAlertSettings    bool                       `json:"useGlobalAlertSettings"`
 	AlertSettings             AlertSettings              `json:"alertSettings,omitempty"`
 	SetupSnippetID            int64                      `json:"setupSnippetId,omitempty"`
@@ -618,8 +627,12 @@ type Group struct {
 	UpdatedAt                 time.Time                  `json:"updatedAt"`
 
 	// Pointers
-	RuntimeID        *string   `json:"runtimeId"`
-	PrivateLocations *[]string `json:"privateLocations"`
+	RuntimeID        *string        `json:"runtimeId"`
+	PrivateLocations *[]string      `json:"privateLocations"`
+	RetryStrategy    *RetryStrategy `json:"retryStrategy,omitempty"`
+
+	// Deprecated: this property will be removed in future versions. Please use RetryStrategy instead.
+	DoubleCheck bool `json:"doubleCheck"`
 }
 
 // APICheckDefaults represents the default settings for API checks within a


### PR DESCRIPTION
## Affected Components
* [x] New Features
* [ ] Bug Fixing
* [ ] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
This PR adds support for retry strategies to checks and check groups.

* double check is marked as deprecated, since it will be replaced by retry strategies
* We store a `*RetryStrategy` rather than a `RetryStrategy`. This makes it possible to have `nil` as the retry strategy. I haven't written much Go, so let me know if there's a more idiomatic way to do this. We already do the same for `BasicAuth` in `Request`.