### PR TITLE
feat(parallel): add `runParallel` to GO check and group constructs [s…

### DIFF
--- a/types.go
+++ b/types.go
@@ -445,6 +445,7 @@ type Check struct {
 	Activated                 bool                       `json:"activated"`
 	Muted                     bool                       `json:"muted"`
 	ShouldFail                bool                       `json:"shouldFail"`
+	RunParallel               bool                       `json:"runParallel"`
 	Locations                 []string                   `json:"locations,omitempty"`
 	DegradedResponseTime      int                        `json:"degradedResponseTime"`
 	MaxResponseTime           int                        `json:"maxResponseTime"`
@@ -487,6 +488,7 @@ type MultiStepCheck struct {
 	Activated                 bool                       `json:"activated"`
 	Muted                     bool                       `json:"muted"`
 	ShouldFail                bool                       `json:"shouldFail"`
+	RunParallel               bool                       `json:"runParallel"`
 	Locations                 []string                   `json:"locations,omitempty"`
 	Script                    string                     `json:"script,omitempty"`
 	EnvironmentVariables      []EnvironmentVariable      `json:"environmentVariables"`
@@ -645,6 +647,7 @@ type Group struct {
 	Name                      string                     `json:"name"`
 	Activated                 bool                       `json:"activated"`
 	Muted                     bool                       `json:"muted"`
+	RunParallel               bool                       `json:"runParallel"`
 	Tags                      []string                   `json:"tags"`
 	Locations                 []string                   `json:"locations"`
 	Concurrency               int                        `json:"concurrency"`


### PR DESCRIPTION
…c-18211]

## Affected Components
* [x] New Features
* [ ] Bug Fixing
* [ ] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [ ] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->
Add `runParallel` to check and group constructs to allow simultaneous check run scheduling on multi-locations.

If set to false, the check run will be scheduled in the different locations in a round-robin fashion.