### PR TITLE
fix: pass empty Locations and PrivateLocations to backend [sc-23129]

### DIFF
--- a/checkly.go
+++ b/checkly.go
@@ -66,27 +66,7 @@ func (c *client) Create(
 	ctx context.Context,
 	check Check,
 ) (*Check, error) {
-	data, err := json.Marshal(check)
-	if err != nil {
-		return nil, err
-	}
-	status, res, err := c.apiCall(
-		ctx,
-		http.MethodPost,
-		withAutoAssignAlertsFlag("checks"),
-		data,
-	)
-	if err != nil {
-		return nil, err
-	}
-	if status != http.StatusCreated {
-		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
-	}
-	var result Check
-	if err = json.NewDecoder(strings.NewReader(res)).Decode(&result); err != nil {
-		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
-	}
-	return &result, nil
+	return c.CreateCheck(ctx, check)
 }
 
 // Update updates an existing check with the specified details. It returns the
@@ -98,28 +78,7 @@ func (c *client) Update(
 	ctx context.Context,
 	ID string, check Check,
 ) (*Check, error) {
-	data, err := json.Marshal(check)
-	if err != nil {
-		return nil, err
-	}
-	status, res, err := c.apiCall(
-		ctx,
-		http.MethodPut,
-		withAutoAssignAlertsFlag(fmt.Sprintf("checks/%s", ID)),
-		data,
-	)
-	if err != nil {
-		return nil, err
-	}
-	if status != http.StatusOK {
-		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
-	}
-	var result Check
-	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
-	if err != nil {
-		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
-	}
-	return &result, nil
+	return c.UpdateCheck(ctx, ID, check)
 }
 
 // Delete deletes the check with the specified ID.
@@ -130,19 +89,7 @@ func (c *client) Delete(
 	ctx context.Context,
 	ID string,
 ) error {
-	status, res, err := c.apiCall(
-		ctx,
-		http.MethodDelete,
-		fmt.Sprintf("checks/%s", ID),
-		nil,
-	)
-	if err != nil {
-		return err
-	}
-	if status != http.StatusNoContent {
-		return fmt.Errorf("unexpected response status %d: %q", status, res)
-	}
-	return nil
+	return c.DeleteCheck(ctx, ID)
 }
 
 // Get takes the ID of an existing check, and returns the check parameters, or
@@ -278,6 +225,14 @@ func (c *client) UpdateCheck(
 	ctx context.Context,
 	ID string, check Check,
 ) (*Check, error) {
+	// A nil value for a list will cause the backend to not update the value.
+	// We must send empty lists instead.
+	if check.Locations == nil {
+		check.Locations = []string{}
+	}
+	if check.PrivateLocations == nil {
+		check.PrivateLocations = &[]string{}
+	}
 	data, err := json.Marshal(check)
 	if err != nil {
 		return nil, err
@@ -337,6 +292,14 @@ func (c *client) UpdateTCPCheck(
 	ID string,
 	check TCPCheck,
 ) (*TCPCheck, error) {
+	// A nil value for a list will cause the backend to not update the value.
+	// We must send empty lists instead.
+	if check.Locations == nil {
+		check.Locations = []string{}
+	}
+	if check.PrivateLocations == nil {
+		check.PrivateLocations = &[]string{}
+	}
 	// Unfortunately `checkType` is required for this endpoint, so sneak it in
 	// using an anonymous struct.
 	payload := struct {
@@ -532,6 +495,14 @@ func (c *client) UpdateGroup(
 	ID int64,
 	group Group,
 ) (*Group, error) {
+	// A nil value for a list will cause the backend to not update the value.
+	// We must send empty lists instead.
+	if group.Locations == nil {
+		group.Locations = []string{}
+	}
+	if group.PrivateLocations == nil {
+		group.PrivateLocations = &[]string{}
+	}
 	data, err := json.Marshal(group)
 	if err != nil {
 		return nil, err

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -184,7 +184,7 @@ func TestCreate(t *testing.T) {
 	t.Parallel()
 	ts := cannedResponseServer(t,
 		http.MethodPost,
-		"/v1/checks/api?autoAssignAlerts=false",
+		"/v1/checks?autoAssignAlerts=false",
 		validateCheck,
 		http.StatusCreated,
 		"CreateCheck.json",

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -27,14 +27,15 @@ import (
 var wantCheckID = "73d29e72-6540-4bb5-967e-e07fa2c9465e"
 
 var wantCheck = checkly.Check{
-	Name:        "test",
-	Type:        checkly.TypeAPI,
-	Frequency:   10,
-	Activated:   true,
-	Muted:       false,
-	DoubleCheck: true,
-	ShouldFail:  false,
-	Locations:   []string{"eu-west-1"},
+	Name:             "test",
+	Type:             checkly.TypeAPI,
+	Frequency:        10,
+	Activated:        true,
+	Muted:            false,
+	DoubleCheck:      true,
+	ShouldFail:       false,
+	Locations:        []string{"eu-west-1"},
+	PrivateLocations: &[]string{},
 	Request: checkly.Request{
 		Method: http.MethodGet,
 		URL:    "https://example.com",
@@ -161,14 +162,16 @@ func TestAPIError(t *testing.T) {
 	t.Parallel()
 	ts := cannedResponseServer(t,
 		http.MethodPost,
-		"/v1/checks?autoAssignAlerts=false",
+		"/v1/checks/api?autoAssignAlerts=false",
 		validateAnything,
 		http.StatusBadRequest,
 		"BadRequest.json",
 	)
 	defer ts.Close()
 	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
-	_, err := client.Create(context.Background(), checkly.Check{})
+	_, err := client.CreateCheck(context.Background(), checkly.Check{
+		Type: checkly.TypeAPI,
+	})
 	if err == nil {
 		t.Error("want error when API returns 'bad request' status, got nil")
 	}
@@ -181,7 +184,7 @@ func TestCreate(t *testing.T) {
 	t.Parallel()
 	ts := cannedResponseServer(t,
 		http.MethodPost,
-		"/v1/checks?autoAssignAlerts=false",
+		"/v1/checks/api?autoAssignAlerts=false",
 		validateCheck,
 		http.StatusCreated,
 		"CreateCheck.json",
@@ -334,12 +337,13 @@ func TestDeleteCheck(t *testing.T) {
 var wantGroupID int64 = 135
 
 var wantGroup = checkly.Group{
-	Name:        "test",
-	Activated:   true,
-	Muted:       false,
-	Tags:        []string{"auto"},
-	Locations:   []string{"eu-west-1"},
-	Concurrency: 3,
+	Name:             "test",
+	Activated:        true,
+	Muted:            false,
+	Tags:             []string{"auto"},
+	Locations:        []string{"eu-west-1"},
+	PrivateLocations: &[]string{},
+	Concurrency:      3,
 	APICheckDefaults: checkly.APICheckDefaults{
 		BaseURL: "example.com/api/test",
 		Headers: []checkly.KeyValue{
@@ -429,7 +433,7 @@ func TestCreateGroup(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	ignored := cmpopts.IgnoreFields(checkly.Group{}, "ID", "AlertChannelSubscriptions")
+	ignored := cmpopts.IgnoreFields(checkly.Group{}, "ID", "AlertChannelSubscriptions", "PrivateLocations")
 	if !cmp.Equal(wantGroup, *gotGroup, ignored) {
 		t.Error(cmp.Diff(wantGroup, *gotGroup, ignoreGroupFields))
 	}
@@ -450,7 +454,7 @@ func TestGetGroup(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	ignored := cmpopts.IgnoreFields(checkly.Group{}, "ID", "AlertChannelSubscriptions")
+	ignored := cmpopts.IgnoreFields(checkly.Group{}, "ID", "AlertChannelSubscriptions", "PrivateLocations")
 	if !cmp.Equal(wantGroup, *gotGroup, ignored) {
 		t.Error(cmp.Diff(wantGroup, *gotGroup, ignored))
 	}
@@ -471,7 +475,7 @@ func TestUpdateGroup(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	ignored := cmpopts.IgnoreFields(checkly.Group{}, "ID", "AlertChannelSubscriptions")
+	ignored := cmpopts.IgnoreFields(checkly.Group{}, "ID", "AlertChannelSubscriptions", "PrivateLocations")
 	if !cmp.Equal(wantGroup, *gotGroup, ignored) {
 		t.Error(cmp.Diff(wantGroup, *gotGroup, ignoreGroupFields))
 	}

--- a/types.go
+++ b/types.go
@@ -474,7 +474,7 @@ type Check struct {
 	Muted                     bool                       `json:"muted"`
 	ShouldFail                bool                       `json:"shouldFail"`
 	RunParallel               bool                       `json:"runParallel"`
-	Locations                 []string                   `json:"locations,omitempty"`
+	Locations                 []string                   `json:"locations"`
 	DegradedResponseTime      int                        `json:"degradedResponseTime"`
 	MaxResponseTime           int                        `json:"maxResponseTime"`
 	Script                    string                     `json:"script,omitempty"`
@@ -517,7 +517,7 @@ type MultiStepCheck struct {
 	Muted                     bool                       `json:"muted"`
 	ShouldFail                bool                       `json:"shouldFail"`
 	RunParallel               bool                       `json:"runParallel"`
-	Locations                 []string                   `json:"locations,omitempty"`
+	Locations                 []string                   `json:"locations"`
 	Script                    string                     `json:"script,omitempty"`
 	EnvironmentVariables      []EnvironmentVariable      `json:"environmentVariables"`
 	Tags                      []string                   `json:"tags,omitempty"`
@@ -559,7 +559,7 @@ type TCPCheck struct {
 	Muted                     bool                       `json:"muted"`
 	ShouldFail                bool                       `json:"shouldFail"`
 	RunParallel               bool                       `json:"runParallel"`
-	Locations                 []string                   `json:"locations,omitempty"`
+	Locations                 []string                   `json:"locations"`
 	DegradedResponseTime      int                        `json:"degradedResponseTime,omitempty"`
 	MaxResponseTime           int                        `json:"maxResponseTime,omitempty"`
 	Tags                      []string                   `json:"tags,omitempty"`
@@ -569,7 +569,7 @@ type TCPCheck struct {
 	GroupID                   int64                      `json:"groupId,omitempty"`
 	GroupOrder                int                        `json:"groupOrder,omitempty"`
 	AlertChannelSubscriptions []AlertChannelSubscription `json:"alertChannelSubscriptions,omitempty"`
-	PrivateLocations          *[]string                  `json:"privateLocations,omitempty"`
+	PrivateLocations          *[]string                  `json:"privateLocations"`
 	RuntimeID                 *string                    `json:"runtimeId"`
 	RetryStrategy             *RetryStrategy             `json:"retryStrategy,omitempty"`
 	CreatedAt                 time.Time                  `json:"created_at,omitempty"`


### PR DESCRIPTION
When `omitempty` is specified for a property, the property is not sent to the server. Our `PUT` endpoints however act like `PATCH` would, meaning that partial updates are supported. When a property is not set, it is kept intact, even though the intention most likely was to remove it. Furthermore, using `null` value causes the same behavior as if the property was never given, so removing `omitempty` is not enough. Instead, we force empty `Locations` and `PrivateLocations` to always be sent as `[]` by initializing them as empty slices if not set.

The same issue likely exists for all other slices that have been marked `omitempty`. Whether they can also be changed or not requires some additional research. For now, only these two properties have been changed.

## Affected Components
* [ ] New Features
* [x] Bug Fixing
* [ ] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->