### PR TITLE
fix(tests): use retryStrategy in favor of deprecated doubleCheck [sc-23400]

### DIFF
--- a/checkly_test.go
+++ b/checkly_test.go
@@ -27,12 +27,16 @@ import (
 var wantCheckID = "73d29e72-6540-4bb5-967e-e07fa2c9465e"
 
 var wantCheck = checkly.Check{
-	Name:             "test",
-	Type:             checkly.TypeAPI,
-	Frequency:        10,
-	Activated:        true,
-	Muted:            false,
-	DoubleCheck:      true,
+	Name:      "test",
+	Type:      checkly.TypeAPI,
+	Frequency: 10,
+	Activated: true,
+	Muted:     false,
+	RetryStrategy: &checkly.RetryStrategy{
+		Type:               "FIXED",
+		MaxRetries:         1,
+		MaxDurationSeconds: 600,
+	},
 	ShouldFail:       false,
 	Locations:        []string{"eu-west-1"},
 	PrivateLocations: &[]string{},
@@ -376,7 +380,11 @@ var wantGroup = checkly.Group{
 			Value: "Hello world",
 		},
 	},
-	DoubleCheck:            true,
+	RetryStrategy: &checkly.RetryStrategy{
+		Type:               "FIXED",
+		MaxRetries:         1,
+		MaxDurationSeconds: 600,
+	},
 	UseGlobalAlertSettings: false,
 	AlertSettings: checkly.AlertSettings{
 		EscalationType: checkly.RunBased,

--- a/fixtures/CreateCheck.json
+++ b/fixtures/CreateCheck.json
@@ -38,7 +38,11 @@
   },
   "frequency": 10,
   "muted": false,
-  "doubleCheck": true,
+  "retryStrategy": {
+    "type": "FIXED",
+    "maxRetries": 1,
+    "maxDurationSeconds": 600
+  },
   "locations": [
     "eu-west-1"
   ],
@@ -66,7 +70,7 @@
     },
     "parallelRunFailureThreshold": {
       "enabled": false,
- 		  "percentage": 10
+      "percentage": 10
     }
   },
   "script": "foo",

--- a/fixtures/CreateGroup.json
+++ b/fixtures/CreateGroup.json
@@ -45,7 +45,11 @@
       "locked": false
     }
   ],
-  "doubleCheck": true,
+  "retryStrategy": {
+    "type": "FIXED",
+    "maxRetries": 1,
+    "maxDurationSeconds": 600
+  },
   "useGlobalAlertSettings": false,
   "alertSettings": {
     "escalationType": "RUN_BASED",
@@ -61,7 +65,7 @@
     },
     "parallelRunFailureThreshold": {
       "enabled": false,
- 		  "percentage": 10
+      "percentage": 10
     }
   },
   "alertChannelSubscriptions": [

--- a/fixtures/GetCheck.json
+++ b/fixtures/GetCheck.json
@@ -38,7 +38,11 @@
   },
   "frequency": 10,
   "muted": false,
-  "doubleCheck": true,
+  "retryStrategy": {
+    "type": "FIXED",
+    "maxRetries": 1,
+    "maxDurationSeconds": 600
+  },
   "locations": [
     "eu-west-1"
   ],
@@ -66,7 +70,7 @@
     },
     "parallelRunFailureThreshold": {
       "enabled": false,
- 		  "percentage": 10
+      "percentage": 10
     }
   },
   "script": "foo",

--- a/fixtures/UpdateCheck.json
+++ b/fixtures/UpdateCheck.json
@@ -38,7 +38,11 @@
   },
   "frequency": 10,
   "muted": false,
-  "doubleCheck": true,
+  "retryStrategy": {
+    "type": "FIXED",
+    "maxRetries": 1,
+    "maxDurationSeconds": 600
+  },
   "locations": [
     "eu-west-1"
   ],
@@ -66,7 +70,7 @@
     },
     "parallelRunFailureThreshold": {
       "enabled": false,
- 		  "percentage": 10
+      "percentage": 10
     }
   },
   "script": "foo",

--- a/fixtures/UpdateGroup.json
+++ b/fixtures/UpdateGroup.json
@@ -38,7 +38,7 @@
     },
     "parallelRunFailureThreshold": {
       "enabled": false,
- 		  "percentage": 10
+      "percentage": 10
     },
     "escalationType": "RUN_BASED",
     "runBasedEscalation": {
@@ -62,7 +62,11 @@
   "activated": true,
   "muted": false,
   "useGlobalAlertSettings": false,
-  "doubleCheck": true,
+  "retryStrategy": {
+    "type": "FIXED",
+    "maxRetries": 1,
+    "maxDurationSeconds": 600
+  },
   "locations": [
     "eu-west-1"
   ],


### PR DESCRIPTION
DoubleCheck is now being converted to retryStrategy at the API level which broke tests. Use retryStrategy instead.

Some fixture files had incorrect indentation so there are a few unrelated lines that have changed. It's minor enough to keep in this PR.

## Affected Components
* [ ] New Features
* [ ] Bug Fixing
* [ ] Types
* [x] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->