### PR TITLE
feat: add status pages and status page services [sc-23757]

### DIFF
--- a/checkly.go
+++ b/checkly.go
@@ -1393,6 +1393,166 @@ func (c *client) DeleteClientCertificate(
 	return nil
 }
 
+func (c *client) CreateStatusPage(
+	ctx context.Context,
+	page StatusPage,
+) (*StatusPage, error) {
+	data, err := json.Marshal(page)
+	if err != nil {
+		return nil, err
+	}
+	status, res, err := c.apiCall(ctx, http.MethodPost, "status-pages", data)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected response status: %d, res: %q", status, res)
+	}
+	var result StatusPage
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
+func (c *client) GetStatusPage(
+	ctx context.Context,
+	ID string,
+) (*StatusPage, error) {
+	status, res, err := c.apiCall(ctx, http.MethodGet, fmt.Sprintf("status-pages/%s", ID), nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result StatusPage
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %q: %v", res, err)
+	}
+	return &result, nil
+}
+
+func (c *client) UpdateStatusPage(
+	ctx context.Context,
+	ID string,
+	page StatusPage,
+) (*StatusPage, error) {
+	data, err := json.Marshal(page)
+	if err != nil {
+		return nil, err
+	}
+	status, res, err := c.apiCall(ctx, http.MethodPut, fmt.Sprintf("status-pages/%s", ID), data)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status: %d, res: %q", status, res)
+	}
+	var result StatusPage
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
+func (c *client) DeleteStatusPage(
+	ctx context.Context,
+	ID string,
+) error {
+	status, res, err := c.apiCall(ctx, http.MethodDelete, fmt.Sprintf("status-pages/%s", ID), nil)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusNoContent {
+		return fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	return nil
+}
+
+func (c *client) CreateStatusPageService(
+	ctx context.Context,
+	service StatusPageService,
+) (*StatusPageService, error) {
+	data, err := json.Marshal(service)
+	if err != nil {
+		return nil, err
+	}
+	status, res, err := c.apiCall(ctx, http.MethodPost, "status-pages/services", data)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected response status: %d, res: %q", status, res)
+	}
+	var result StatusPageService
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
+func (c *client) GetStatusPageService(
+	ctx context.Context,
+	ID string,
+) (*StatusPageService, error) {
+	status, res, err := c.apiCall(ctx, http.MethodGet, fmt.Sprintf("status-pages/services/%s", ID), nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result StatusPageService
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %q: %v", res, err)
+	}
+	return &result, nil
+}
+
+func (c *client) UpdateStatusPageService(
+	ctx context.Context,
+	ID string,
+	service StatusPageService,
+) (*StatusPageService, error) {
+	data, err := json.Marshal(service)
+	if err != nil {
+		return nil, err
+	}
+	status, res, err := c.apiCall(ctx, http.MethodPut, fmt.Sprintf("status-pages/services/%s", ID), data)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status: %d, res: %q", status, res)
+	}
+	var result StatusPageService
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
+func (c *client) DeleteStatusPageService(
+	ctx context.Context,
+	ID string,
+) error {
+	status, res, err := c.apiCall(ctx, http.MethodDelete, fmt.Sprintf("status-pages/services/%s", ID), nil)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusNoContent {
+		return fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	return nil
+}
+
 func payloadFromAlertChannel(ac AlertChannel) map[string]interface{} {
 	payload := map[string]interface{}{
 		"id":     ac.ID,

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -1664,3 +1664,198 @@ func TestDeleteClientCertificate(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func validateStatusPageService(t *testing.T, body []byte) {
+	var payload checkly.StatusPageService
+	err := json.Unmarshal(body, &payload)
+	if err != nil {
+		t.Fatalf("decoding error for data %q: %v", body, err)
+	}
+	if !cmp.Equal(testStatusPageService, payload) {
+		t.Error(cmp.Diff(testStatusPageService, payload))
+	}
+}
+
+var testStatusPageService = checkly.StatusPageService{
+	ID:   "8a894b49-467f-4af6-9230-cd4d3bd452f4",
+	Name: "Foo service",
+}
+
+var ignoreStatusPageServiceFields = cmpopts.IgnoreFields(checkly.StatusPageService{}, "ID")
+
+func TestCreateStatusPageService(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodPost,
+		"/v1/status-pages/services",
+		validateStatusPageService,
+		http.StatusCreated,
+		"CreateStatusPageService.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	response, err := client.CreateStatusPageService(context.Background(), testStatusPageService)
+	if err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(testStatusPageService, *response, ignoreStatusPageServiceFields) {
+		t.Error(cmp.Diff(testStatusPageService, *response, ignoreStatusPageServiceFields))
+	}
+}
+
+func TestDeleteStatusPageService(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodDelete,
+		fmt.Sprintf("/v1/status-pages/services/%s", testStatusPageService.ID),
+		validateEmptyBody,
+		http.StatusNoContent,
+		"Empty.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	err := client.DeleteStatusPageService(context.Background(), testStatusPageService.ID)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpdateStatusPageService(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodPut,
+		fmt.Sprintf("/v1/status-pages/services/%s", testStatusPageService.ID),
+		validateStatusPageService,
+		http.StatusOK,
+		"UpdateStatusPageService.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	_, err := client.UpdateStatusPageService(context.Background(), testStatusPageService.ID, testStatusPageService)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGetStatusPageService(t *testing.T) {
+	ts := cannedResponseServer(t,
+		http.MethodGet,
+		fmt.Sprintf("/v1/status-pages/services/%s", testStatusPageService.ID),
+		validateEmptyBody,
+		http.StatusOK,
+		"GetStatusPageService.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	response, err := client.GetStatusPageService(context.Background(), testStatusPageService.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cmp.Equal(testStatusPageService, *response, ignoreStatusPageServiceFields) {
+		t.Error(cmp.Diff(testStatusPageService, *response, ignoreStatusPageServiceFields))
+	}
+}
+
+func validateStatusPage(t *testing.T, body []byte) {
+	var payload checkly.StatusPage
+	err := json.Unmarshal(body, &payload)
+	if err != nil {
+		t.Fatalf("decoding error for data %q: %v", body, err)
+	}
+	if !cmp.Equal(testStatusPage, payload) {
+		t.Error(cmp.Diff(testStatusPage, payload))
+	}
+}
+
+var testStatusPage = checkly.StatusPage{
+	ID:           "cd8d05a4-c292-4dc4-a78f-1dea65e5457e",
+	Name:         "Foo status page",
+	URL:          "foo-status-page",
+	DefaultTheme: checkly.StatusPageThemeAuto,
+	Cards: []checkly.StatusPageCard{
+		{
+			Name: "Foo card",
+			Services: []checkly.StatusPageService{
+				{
+					ID:   "8a894b49-467f-4af6-9230-cd4d3bd452f4",
+					Name: "Foo service",
+				},
+			},
+		},
+	},
+}
+
+var ignoreStatusPageFields = cmpopts.IgnoreFields(checkly.StatusPage{}, "ID")
+
+func TestCreateStatusPage(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodPost,
+		"/v1/status-pages",
+		validateStatusPage,
+		http.StatusCreated,
+		"CreateStatusPage.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	response, err := client.CreateStatusPage(context.Background(), testStatusPage)
+	if err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(testStatusPage, *response, ignoreStatusPageFields) {
+		t.Error(cmp.Diff(testStatusPage, *response, ignoreStatusPageFields))
+	}
+}
+
+func TestDeleteStatusPage(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodDelete,
+		fmt.Sprintf("/v1/status-pages/%s", testStatusPage.ID),
+		validateEmptyBody,
+		http.StatusNoContent,
+		"Empty.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	err := client.DeleteStatusPage(context.Background(), testStatusPage.ID)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpdateStatusPage(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodPut,
+		fmt.Sprintf("/v1/status-pages/%s", testStatusPage.ID),
+		validateStatusPage,
+		http.StatusOK,
+		"UpdateStatusPage.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	_, err := client.UpdateStatusPage(context.Background(), testStatusPage.ID, testStatusPage)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGetStatusPage(t *testing.T) {
+	ts := cannedResponseServer(t,
+		http.MethodGet,
+		fmt.Sprintf("/v1/status-pages/%s", testStatusPage.ID),
+		validateEmptyBody,
+		http.StatusOK,
+		"GetStatusPage.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	response, err := client.GetStatusPage(context.Background(), testStatusPage.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cmp.Equal(testStatusPage, *response, ignoreStatusPageFields) {
+		t.Error(cmp.Diff(testStatusPage, *response, ignoreStatusPageFields))
+	}
+}

--- a/fixtures/CreateStatusPage.json
+++ b/fixtures/CreateStatusPage.json
@@ -1,0 +1,17 @@
+{
+  "id": "cd8d05a4-c292-4dc4-a78f-1dea65e5457e",
+  "name": "Foo status page",
+  "url": "foo-status-page",
+  "defaultTheme": "AUTO",
+  "cards": [
+    {
+      "name": "Foo card",
+      "services": [
+        {
+          "id": "8a894b49-467f-4af6-9230-cd4d3bd452f4",
+          "name": "Foo service"
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/CreateStatusPageService.json
+++ b/fixtures/CreateStatusPageService.json
@@ -1,0 +1,4 @@
+{
+  "id": "8a894b49-467f-4af6-9230-cd4d3bd452f4",
+  "name": "Foo service"
+}

--- a/fixtures/GetStatusPage.json
+++ b/fixtures/GetStatusPage.json
@@ -1,0 +1,17 @@
+{
+  "id": "cd8d05a4-c292-4dc4-a78f-1dea65e5457e",
+  "name": "Foo status page",
+  "url": "foo-status-page",
+  "defaultTheme": "AUTO",
+  "cards": [
+    {
+      "name": "Foo card",
+      "services": [
+        {
+          "id": "8a894b49-467f-4af6-9230-cd4d3bd452f4",
+          "name": "Foo service"
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/GetStatusPageService.json
+++ b/fixtures/GetStatusPageService.json
@@ -1,0 +1,4 @@
+{
+  "id": "8a894b49-467f-4af6-9230-cd4d3bd452f4",
+  "name": "Foo service"
+}

--- a/fixtures/UpdateStatusPage.json
+++ b/fixtures/UpdateStatusPage.json
@@ -1,0 +1,17 @@
+{
+  "id": "cd8d05a4-c292-4dc4-a78f-1dea65e5457e",
+  "name": "Foo status page",
+  "url": "foo-status-page",
+  "defaultTheme": "AUTO",
+  "cards": [
+    {
+      "name": "Foo card",
+      "services": [
+        {
+          "id": "8a894b49-467f-4af6-9230-cd4d3bd452f4",
+          "name": "Foo service"
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/UpdateStatusPageService.json
+++ b/fixtures/UpdateStatusPageService.json
@@ -1,0 +1,4 @@
+{
+  "id": "8a894b49-467f-4af6-9230-cd4d3bd452f4",
+  "name": "Foo service"
+}

--- a/types.go
+++ b/types.go
@@ -387,6 +387,58 @@ type Client interface {
 		ID string,
 	) error
 
+	// CreateStatusPage creates a new status page and returns the created
+	// resource.
+	CreateStatusPage(
+		ctx context.Context,
+		page StatusPage,
+	) (*StatusPage, error)
+
+	// GetStatusPage retrieves a status page.
+	GetStatusPage(
+		ctx context.Context,
+		ID string,
+	) (*StatusPage, error)
+
+	// UpdateStatusPage updates a status page.
+	UpdateStatusPage(
+		ctx context.Context,
+		ID string,
+		page StatusPage,
+	) (*StatusPage, error)
+
+	// DeleteStatusPage deletes a status page.
+	DeleteStatusPage(
+		ctx context.Context,
+		ID string,
+	) error
+
+	// CreateStatusPageService creates a new status page service and returns
+	// the created resource.
+	CreateStatusPageService(
+		ctx context.Context,
+		service StatusPageService,
+	) (*StatusPageService, error)
+
+	// GetStatusPageService retrieves a status page service.
+	GetStatusPageService(
+		ctx context.Context,
+		ID string,
+	) (*StatusPageService, error)
+
+	// UpdateStatusPageService updates a status page service.
+	UpdateStatusPageService(
+		ctx context.Context,
+		ID string,
+		service StatusPageService,
+	) (*StatusPageService, error)
+
+	// DeleteStatusPageService deletes a status page service.
+	DeleteStatusPageService(
+		ctx context.Context,
+		ID string,
+	) error
+
 	// SetAccountId sets ID on a client which is required when using User API keys.
 	SetAccountId(ID string)
 
@@ -1111,4 +1163,60 @@ type ClientCertificate struct {
 
 	// CreatedAt is the time when the client certificate was created.
 	CreatedAt time.Time `json:"created_at"`
+}
+
+type StatusPageTheme string
+
+const (
+	StatusPageThemeAuto  StatusPageTheme = "AUTO"
+	StatusPageThemeDark  StatusPageTheme = "DARK"
+	StatusPageThemeLight StatusPageTheme = "LIGHT"
+)
+
+type StatusPage struct {
+	// ID is the Checkly identifier of the status page.
+	ID string `json:"id,omitempty"`
+
+	// Name is the name of the status page.
+	Name string `json:"name"`
+
+	// URL is the unique subdomain of the status page.
+	URL string `json:"url"`
+
+	// CustomDomain is an optional user-managed domain that hosts the status
+	// page.
+	CustomDomain string `json:"customDomain,omitempty"`
+
+	// Logo is a URL to an image file to use as the logo for the status page.
+	Logo string `json:"logo,omitempty"`
+
+	// RedirectTo is the URL the user should be redirected to when clicking
+	// the logo.
+	RedirectTo string `json:"redirectTo,omitempty"`
+
+	// Favicon is a URL to an image file to use as the favicon of the status
+	// page.
+	Favicon string `json:"favicon,omitempty"`
+
+	// DefaultTheme is the default theme of the status page.
+	DefaultTheme StatusPageTheme `json:"defaultTheme,omitempty"`
+
+	// Cards is a list of cards to include on the status page.
+	Cards []StatusPageCard `json:"cards"`
+}
+
+type StatusPageCard struct {
+	// Name is the name of the card.
+	Name string `json:"name"`
+
+	// Services is the list of services to include in the card.
+	Services []StatusPageService `json:"services"`
+}
+
+type StatusPageService struct {
+	// ID is the Checkly identifier of the service.
+	ID string `json:"id,omitempty"`
+
+	// Name is the name of the service.
+	Name string `json:"name"`
 }


### PR DESCRIPTION
Adds support for status pages and status page services.

Existing style has been respected, or in other words it's not pretty.

## Affected Components
* [x] New Features
* [ ] Bug Fixing
* [x] Types
* [x] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->