### PR TITLE
feat: add EnableIncidents to Dashboard [sc-25022]

### DIFF
--- a/checkly_test.go
+++ b/checkly_test.go
@@ -1121,6 +1121,7 @@ var testDashboard = checkly.Dashboard{
 	HideTags:           false,
 	ChecksPerPage:      15,
 	UseTagsAndOperator: true,
+	EnableIncidents:    true,
 }
 
 var ignoreDashboardFields = cmpopts.IgnoreFields(checkly.Dashboard{}, "DashboardID", "CreatedAt", "ID", "Keys")

--- a/fixtures/CreateDashboard.json
+++ b/fixtures/CreateDashboard.json
@@ -9,6 +9,7 @@
   "width": "FULL",
   "checksPerPage": 15,
   "useTagsAndOperator": true,
+  "enableIncidents": true,
   "refreshRate": 60,
   "paginate": true,
   "paginationRate": 30,

--- a/types.go
+++ b/types.go
@@ -1129,6 +1129,7 @@ type Dashboard struct {
 	Tags               []string       `json:"tags,omitempty"`
 	HideTags           bool           `json:"hideTags,omitempty"`
 	UseTagsAndOperator bool           `json:"useTagsAndOperator,omitempty"`
+	EnableIncidents    bool           `json:"enableIncidents"`
 	CreatedAt          string         `json:"created_at"`
 	UpdatedAt          string         `json:"updated_at"`
 	Keys               []DashboardKey `json:"keys,omitempty"`


### PR DESCRIPTION
Adds a new `EnableIncidents` flag to `Dashboard`, which will be used to resolve https://github.com/checkly/terraform-provider-checkly/issues/248.

## Affected Components
* [x] New Features
* [ ] Bug Fixing
* [x] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->