### PR TITLE
feat: expose more Dashboard properties [sc-25022]

### DIFF
--- a/checkly_integration_test.go
+++ b/checkly_integration_test.go
@@ -24,11 +24,11 @@ func setupClient(t *testing.T) checkly.Client {
 	}
 	apiKey := os.Getenv("CHECKLY_API_KEY")
 	if apiKey == "" {
-		t.Error("'CHECKLY_API_KEY' must be set for integration tests")
+		t.Fatal("'CHECKLY_API_KEY' must be set for integration tests")
 	}
 	accountId := os.Getenv("CHECKLY_ACCOUNT_ID")
 	if accountId == "" {
-		t.Error("'CHECKLY_ACCOUNT_ID' must be set for integration tests")
+		t.Fatal("'CHECKLY_ACCOUNT_ID' must be set for integration tests")
 	}
 
 	client := checkly.NewClient(
@@ -47,11 +47,11 @@ func TestCreateIntegration(t *testing.T) {
 
 	gotCheck, err := client.Create(context.Background(), wantCheck)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.Delete(context.Background(), gotCheck.ID)
 	if !cmp.Equal(wantCheck, *gotCheck, ignoreCheckFields) {
-		t.Error(cmp.Diff(wantCheck, *gotCheck, ignoreCheckFields))
+		t.Fatal(cmp.Diff(wantCheck, *gotCheck, ignoreCheckFields))
 	}
 }
 
@@ -59,15 +59,15 @@ func TestGetIntegration(t *testing.T) {
 	client := setupClient(t)
 	check, err := client.Create(context.Background(), wantCheck)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.Delete(context.Background(), check.ID)
 	gotCheck, err := client.Get(context.Background(), check.ID)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if !cmp.Equal(wantCheck, *gotCheck, ignoreCheckFields) {
-		t.Error(cmp.Diff(wantCheck, *gotCheck, ignoreCheckFields))
+		t.Fatal(cmp.Diff(wantCheck, *gotCheck, ignoreCheckFields))
 	}
 }
 
@@ -76,17 +76,17 @@ func TestUpdateIntegration(t *testing.T) {
 	client := setupClient(t)
 	check, err := client.Create(context.Background(), wantCheck)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.Delete(context.Background(), check.ID)
 	updatedCheck := wantCheck
 	updatedCheck.Name = "integrationTestUpdate"
 	gotCheck, err := client.Update(context.Background(), check.ID, updatedCheck)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if !cmp.Equal(updatedCheck, *gotCheck, ignoreCheckFields) {
-		t.Error(cmp.Diff(updatedCheck, *gotCheck, ignoreCheckFields))
+		t.Fatal(cmp.Diff(updatedCheck, *gotCheck, ignoreCheckFields))
 	}
 }
 
@@ -95,10 +95,10 @@ func TestDeleteIntegration(t *testing.T) {
 	client := setupClient(t)
 	check, err := client.Create(context.Background(), wantCheck)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if err := client.Delete(context.Background(), check.ID); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 }
 
@@ -119,19 +119,18 @@ func TestCreateGroupIntegration(t *testing.T) {
 	wantGroupCopy := wantGroup
 	ac, err := makeTestAlertChannel(client)
 	if err != nil {
-		t.Error(err.Error())
-		return
+		t.Fatal(err.Error())
 	}
 	wantGroupCopy.AlertChannelSubscriptions[0].ChannelID = ac.ID
 	gotGroup, err := client.CreateGroup(context.Background(), wantGroupCopy)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.DeleteGroup(context.Background(), gotGroup.ID)
 	// These are set by the APIs
 	ignored := cmpopts.IgnoreFields(checkly.Group{}, "ID", "AlertChannelSubscriptions", "AlertSettings.SSLCertificates", "PrivateLocations")
 	if !cmp.Equal(wantGroupCopy, *gotGroup, ignored) {
-		t.Error(cmp.Diff(wantGroupCopy, *gotGroup, ignored))
+		t.Fatal(cmp.Diff(wantGroupCopy, *gotGroup, ignored))
 	}
 }
 
@@ -142,17 +141,17 @@ func TestGetGroupIntegration(t *testing.T) {
 	wantGroupCopy.AlertChannelSubscriptions[0].ChannelID = ac.ID
 	group, err := client.CreateGroup(context.Background(), wantGroupCopy)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.DeleteGroup(context.Background(), group.ID)
 	gotGroup, err := client.GetGroup(context.Background(), group.ID)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	// These are set by the API
 	wantGroupCopy.AlertChannelSubscriptions = gotGroup.AlertChannelSubscriptions
 	if !cmp.Equal(wantGroupCopy, *gotGroup, ignoreGroupFields) {
-		t.Error(cmp.Diff(wantGroupCopy, *gotGroup, ignoreGroupFields))
+		t.Fatal(cmp.Diff(wantGroupCopy, *gotGroup, ignoreGroupFields))
 	}
 }
 
@@ -163,11 +162,11 @@ func TestCreateDashboardIntegration(t *testing.T) {
 
 	gotDashboard, err := client.CreateDashboard(context.Background(), testDashboard)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.DeleteDashboard(context.Background(), gotDashboard.DashboardID)
 	if !cmp.Equal(testDashboard, *gotDashboard, ignoreDashboardFields) {
-		t.Error(cmp.Diff(testDashboard, *gotDashboard, ignoreDashboardFields))
+		t.Fatal(cmp.Diff(testDashboard, *gotDashboard, ignoreDashboardFields))
 	}
 }
 
@@ -175,15 +174,15 @@ func TestGetDashboardIntegration(t *testing.T) {
 	client := setupClient(t)
 	dash, err := client.CreateDashboard(context.Background(), testDashboard)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.DeleteDashboard(context.Background(), dash.DashboardID)
 	gotDashboard, err := client.GetDashboard(context.Background(), dash.DashboardID)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if !cmp.Equal(testDashboard, *gotDashboard, ignoreDashboardFields) {
-		t.Error(cmp.Diff(testDashboard, *gotDashboard, ignoreDashboardFields))
+		t.Fatal(cmp.Diff(testDashboard, *gotDashboard, ignoreDashboardFields))
 	}
 }
 
@@ -194,11 +193,11 @@ func TestCreateMaintenanceWindowIntegration(t *testing.T) {
 
 	gotMaintenanceWindow, err := client.CreateMaintenanceWindow(context.Background(), testMaintenanceWindow)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.DeleteMaintenanceWindow(context.Background(), gotMaintenanceWindow.ID)
 	if !cmp.Equal(testMaintenanceWindow, *gotMaintenanceWindow, ignoreMaintenanceWindowFields) {
-		t.Error(cmp.Diff(testMaintenanceWindow, *gotMaintenanceWindow, ignoreMaintenanceWindowFields))
+		t.Fatal(cmp.Diff(testMaintenanceWindow, *gotMaintenanceWindow, ignoreMaintenanceWindowFields))
 	}
 }
 
@@ -206,15 +205,15 @@ func TestGetMaintenanceWindowIntegration(t *testing.T) {
 	client := setupClient(t)
 	dash, err := client.CreateMaintenanceWindow(context.Background(), testMaintenanceWindow)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.DeleteMaintenanceWindow(context.Background(), dash.ID)
 	gotMaintenanceWindow, err := client.GetMaintenanceWindow(context.Background(), dash.ID)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if !cmp.Equal(testMaintenanceWindow, *gotMaintenanceWindow, ignoreMaintenanceWindowFields) {
-		t.Error(cmp.Diff(testMaintenanceWindow, *gotMaintenanceWindow, ignoreMaintenanceWindowFields))
+		t.Fatal(cmp.Diff(testMaintenanceWindow, *gotMaintenanceWindow, ignoreMaintenanceWindowFields))
 	}
 }
 
@@ -225,17 +224,17 @@ func TestCreateTriggerCheckIntegration(t *testing.T) {
 
 	gotCheck, err := client.Create(context.Background(), wantCheck)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	gotTriggerCheck, err := client.CreateTriggerCheck(context.Background(), gotCheck.ID)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.Delete(context.Background(), gotCheck.ID)
 
 	if !cmp.Equal(gotCheck.ID, gotTriggerCheck.CheckId, ignoreTriggerCheck) {
-		t.Error(cmp.Diff(gotCheck.ID, gotTriggerCheck.CheckId, ignoreTriggerCheck))
+		t.Fatal(cmp.Diff(gotCheck.ID, gotTriggerCheck.CheckId, ignoreTriggerCheck))
 	}
 }
 
@@ -243,19 +242,19 @@ func TestGetTriggerCheckIntegration(t *testing.T) {
 	client := setupClient(t)
 	gotCheck, err := client.Create(context.Background(), wantCheck)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	tc, err := client.CreateTriggerCheck(context.Background(), gotCheck.ID)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	gotTriggerCheck, err := client.GetTriggerCheck(context.Background(), tc.CheckId)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.Delete(context.Background(), gotCheck.ID)
 	if !cmp.Equal(gotCheck.ID, gotTriggerCheck.CheckId, ignoreTriggerCheck) {
-		t.Error(cmp.Diff(gotCheck.ID, gotTriggerCheck.CheckId, ignoreTriggerCheck))
+		t.Fatal(cmp.Diff(gotCheck.ID, gotTriggerCheck.CheckId, ignoreTriggerCheck))
 	}
 }
 
@@ -265,15 +264,15 @@ func TestCreateTriggerGroupIntegration(t *testing.T) {
 	client := setupClient(t)
 	gotGroup, err := client.CreateGroup(context.Background(), wantGroup)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	gotTriggerGroup, err := client.CreateTriggerGroup(context.Background(), gotGroup.ID)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.DeleteGroup(context.Background(), gotGroup.ID)
 	if !cmp.Equal(gotGroup.ID, gotTriggerGroup.GroupId, ignoreTriggerGroup) {
-		t.Error(cmp.Diff(gotGroup.ID, gotTriggerGroup.GroupId, ignoreTriggerGroup))
+		t.Fatal(cmp.Diff(gotGroup.ID, gotTriggerGroup.GroupId, ignoreTriggerGroup))
 	}
 }
 
@@ -281,19 +280,19 @@ func TestGetTriggerGroupIntegration(t *testing.T) {
 	client := setupClient(t)
 	gotGroup, err := client.CreateGroup(context.Background(), wantGroup)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	tc, err := client.CreateTriggerGroup(context.Background(), gotGroup.ID)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.DeleteTriggerGroup(context.Background(), tc.GroupId)
 	gotTriggerGroup, err := client.GetTriggerGroup(context.Background(), tc.GroupId)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if !cmp.Equal(gotGroup.ID, gotTriggerGroup.GroupId, ignoreTriggerGroup) {
-		t.Error(cmp.Diff(gotGroup.ID, gotTriggerGroup.GroupId, ignoreTriggerGroup))
+		t.Fatal(cmp.Diff(gotGroup.ID, gotTriggerGroup.GroupId, ignoreTriggerGroup))
 	}
 }
 
@@ -304,26 +303,26 @@ func TestCreatePrivateLocationIntegration(t *testing.T) {
 
 	gotPrivateLocation, err := client.CreatePrivateLocation(context.Background(), testPrivateLocation)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.DeletePrivateLocation(context.Background(), gotPrivateLocation.ID)
 	if !cmp.Equal(testPrivateLocation, *gotPrivateLocation, ignorePrivateLocationFields) {
-		t.Error(cmp.Diff(testPrivateLocation, *gotPrivateLocation, ignorePrivateLocationFields))
+		t.Fatal(cmp.Diff(testPrivateLocation, *gotPrivateLocation, ignorePrivateLocationFields))
 	}
 }
 func TestGetPrivateLocationIntegration(t *testing.T) {
 	client := setupClient(t)
 	pl, err := client.CreatePrivateLocation(context.Background(), testPrivateLocation)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	defer client.DeletePrivateLocation(context.Background(), pl.ID)
 	gotPrivateLocation, err := client.GetPrivateLocation(context.Background(), pl.ID)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	if !cmp.Equal(testPrivateLocation, *gotPrivateLocation, ignorePrivateLocationFields) {
-		t.Error(cmp.Diff(testPrivateLocation, *gotPrivateLocation, ignorePrivateLocationFields))
+		t.Fatal(cmp.Diff(testPrivateLocation, *gotPrivateLocation, ignorePrivateLocationFields))
 	}
 }
 
@@ -411,7 +410,7 @@ func TestClientCertificateCRD(t *testing.T) {
 	}
 
 	if !cmp.Equal(createdClientCertificate, readClientCertificate) {
-		t.Error(cmp.Diff(createdClientCertificate, readClientCertificate, ignorePrivateLocationFields))
+		t.Fatal(cmp.Diff(createdClientCertificate, readClientCertificate, ignorePrivateLocationFields))
 	}
 
 	didDelete = true
@@ -447,7 +446,7 @@ func TestStatusPageServiceCRUD(t *testing.T) {
 	}
 
 	if !cmp.Equal(createdStatusPageService, readStatusPageService) {
-		t.Error(cmp.Diff(createdStatusPageService, readStatusPageService, ignoreStatusPageFields))
+		t.Fatal(cmp.Diff(createdStatusPageService, readStatusPageService, ignoreStatusPageFields))
 	}
 
 	updateStatusPageService := *createdStatusPageService
@@ -529,7 +528,7 @@ func TestStatusPageCRUD(t *testing.T) {
 	readStatusPage.Cards[0].Services[0].Name = createdStatusPageService.Name
 
 	if !cmp.Equal(createdStatusPage, readStatusPage) {
-		t.Error(cmp.Diff(createdStatusPage, readStatusPage, ignoreStatusPageFields))
+		t.Fatal(cmp.Diff(createdStatusPage, readStatusPage, ignoreStatusPageFields))
 	}
 
 	updateStatusPage := *createdStatusPage

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -1104,6 +1104,8 @@ func validateDashboard(t *testing.T, body []byte) {
 	}
 }
 
+var trueVal = true
+
 var testDashboard = checkly.Dashboard{
 	DashboardID:        "abcd1234",
 	CustomDomain:       "is.checkly.online",
@@ -1113,6 +1115,7 @@ var testDashboard = checkly.Dashboard{
 	Link:               "https://www.checklyhq.com",
 	Description:        "Checkly status page",
 	Header:             "Status",
+	ShowHeader:         &trueVal,
 	Width:              "FULL",
 	RefreshRate:        60,
 	Paginate:           true,
@@ -1122,6 +1125,11 @@ var testDashboard = checkly.Dashboard{
 	ChecksPerPage:      15,
 	UseTagsAndOperator: true,
 	EnableIncidents:    true,
+	CustomCSS:          "",
+	ExpandChecks:       false,
+	ShowCheckRunLinks:  false,
+	ShowP95:            &trueVal,
+	ShowP99:            &trueVal,
 }
 
 var ignoreDashboardFields = cmpopts.IgnoreFields(checkly.Dashboard{}, "DashboardID", "CreatedAt", "ID", "Keys")

--- a/fixtures/CreateDashboard.json
+++ b/fixtures/CreateDashboard.json
@@ -1,11 +1,12 @@
 {
-  "customUrl":  "status-page",
-  "customDomain":  "is.checkly.online",
-  "logo":  "https://www.checklyhq.com/images/text_racoon_logo.svg",
-  "favicon":  "https://www.checklyhq.com/images/text_racoon_logo.svg",
+  "customUrl": "status-page",
+  "customDomain": "is.checkly.online",
+  "logo": "https://www.checklyhq.com/images/text_racoon_logo.svg",
+  "favicon": "https://www.checklyhq.com/images/text_racoon_logo.svg",
   "link": "https://www.checklyhq.com",
   "description": "Checkly status page",
   "header": "Status",
+  "showHeader": true,
   "width": "FULL",
   "checksPerPage": 15,
   "useTagsAndOperator": true,
@@ -14,5 +15,10 @@
   "paginate": true,
   "paginationRate": 30,
   "hideTags": false,
-  "tags": ["api"]
+  "tags": ["api"],
+  "customCSS": "",
+  "expandChecks": false,
+  "showCheckRunLinks": false,
+  "showP95": true,
+  "showP99": true
 }

--- a/types.go
+++ b/types.go
@@ -1121,6 +1121,7 @@ type Dashboard struct {
 	Description        string         `json:"description,omitempty"`
 	Favicon            string         `json:"favicon,omitempty"`
 	Header             string         `json:"header,omitempty"`
+	ShowHeader         *bool          `json:"showHeader,omitempty"` // If nil, defaults to true.
 	Width              string         `json:"width,omitempty"`
 	RefreshRate        int            `json:"refreshRate"`
 	ChecksPerPage      int            `json:"checksPerPage,omitempty"`
@@ -1130,6 +1131,11 @@ type Dashboard struct {
 	HideTags           bool           `json:"hideTags,omitempty"`
 	UseTagsAndOperator bool           `json:"useTagsAndOperator,omitempty"`
 	EnableIncidents    bool           `json:"enableIncidents"`
+	ExpandChecks       bool           `json:"expandChecks"`
+	ShowCheckRunLinks  bool           `json:"showCheckRunLinks"`
+	CustomCSS          string         `json:"customCSS"`
+	ShowP95            *bool          `json:"showP95,omitempty"` // If nil, defaults to true.
+	ShowP99            *bool          `json:"showP99,omitempty"` // If nil, defaults to true.
 	CreatedAt          string         `json:"created_at"`
 	UpdatedAt          string         `json:"updated_at"`
 	Keys               []DashboardKey `json:"keys,omitempty"`


### PR DESCRIPTION
This PR exposes the following new properties for Dashboards:

- ShowHeader
- ExpandChecks
- ShowCheckRunLinks
- CustomCSS
- ShowP95
- ShowP99

The properties have been added in a compatible manner, meaning that not specifying the values is going to have the same outcome as explicitly providing their default values. Unfortunately `ShowHeader`, `ShowP95` and `ShowP99` default to true, so they had to made inconvenient pointers.

This change also changes all `t.Error` to `t.Fatal` in the integration test file, because the former does not stop execution which led to a panic party when things went wrong.

## Affected Components
* [ ] New Features
* [ ] Bug Fixing
* [x] Types
* [x] Tests
* [ ] Docs
* [ ] Other

## Style
* [ ] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->