### PR TITLE
fix: set doubleCheck to false when creating/updating monitors so retries can be disabled [SIM-124]

### DIFF
--- a/checkly.go
+++ b/checkly.go
@@ -224,7 +224,15 @@ func (c *client) CreateTCPMonitor(
 	ctx context.Context,
 	monitor TCPMonitor,
 ) (*TCPMonitor, error) {
-	data, err := json.Marshal(monitor)
+	payload := struct {
+		TCPMonitor
+		DoubleCheck bool `json:"doubleCheck"`
+	}{
+		TCPMonitor: monitor,
+		// Unfortunately, this will default to true if not set.
+		DoubleCheck: false,
+	}
+	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
 	}
@@ -253,10 +261,13 @@ func (c *client) CreateURLMonitor(
 ) (*URLMonitor, error) {
 	payload := struct {
 		URLMonitor
-		Request Request `json:"request"`
+		Request     Request `json:"request"`
+		DoubleCheck bool    `json:"doubleCheck"`
 	}{
 		URLMonitor: monitor,
 		Request:    monitor.Request.toRequest(),
+		// Unfortunately, this will default to true if not set.
+		DoubleCheck: false,
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -378,14 +389,17 @@ func (c *client) UpdateTCPMonitor(
 	if monitor.PrivateLocations == nil {
 		monitor.PrivateLocations = &[]string{}
 	}
-	// Unfortunately `checkType` is required for this endpoint, so sneak it in
-	// using an anonymous struct.
 	payload := struct {
 		TCPMonitor
-		Type string `json:"checkType"`
+		Type        string `json:"checkType"`
+		DoubleCheck bool   `json:"doubleCheck"`
 	}{
 		TCPMonitor: monitor,
-		Type:       "TCP",
+		// Unfortunately `checkType` is required for this endpoint, so sneak it in
+		// using an anonymous struct.
+		Type: "TCP",
+		// Unfortunately, this will default to true if not set.
+		DoubleCheck: false,
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -428,12 +442,15 @@ func (c *client) UpdateURLMonitor(
 	// using an anonymous struct.
 	payload := struct {
 		URLMonitor
-		Type    string  `json:"checkType"`
-		Request Request `json:"request"`
+		Type        string  `json:"checkType"`
+		Request     Request `json:"request"`
+		DoubleCheck bool    `json:"doubleCheck"`
 	}{
 		URLMonitor: monitor,
 		Type:       "URL",
 		Request:    monitor.Request.toRequest(),
+		// Unfortunately, this will default to true if not set.
+		DoubleCheck: false,
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {


### PR DESCRIPTION
The property is not exposed for the newer monitor types, but the API level default is true, which means that it is not possible to completely disable retries without also setting doubleCheck to false.

This change makes it so that even though doubleCheck is still not exposed, it's always set to false when needed.

## Affected Components
* [ ] New Features
* [x] Bug Fixing
* [ ] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->