### PR TITLE
fix: removing RetryStrategy is not possible when updating a check/monitor/group [SIM-125]

### DIFF
--- a/types.go
+++ b/types.go
@@ -660,7 +660,7 @@ type Check struct {
 	// Pointers
 	PrivateLocations *[]string        `json:"privateLocations"`
 	RuntimeID        *string          `json:"runtimeId"`
-	RetryStrategy    *RetryStrategy   `json:"retryStrategy,omitempty"`
+	RetryStrategy    *RetryStrategy   `json:"retryStrategy"`
 	TriggerIncident  *IncidentTrigger `json:"triggerIncident"`
 
 	// Deprecated: this property will be removed in future versions.
@@ -695,7 +695,7 @@ type MultiStepCheck struct {
 	// Pointers
 	PrivateLocations *[]string        `json:"privateLocations"`
 	RuntimeID        *string          `json:"runtimeId"`
-	RetryStrategy    *RetryStrategy   `json:"retryStrategy,omitempty"`
+	RetryStrategy    *RetryStrategy   `json:"retryStrategy"`
 	TriggerIncident  *IncidentTrigger `json:"triggerIncident"`
 }
 
@@ -742,7 +742,7 @@ type TCPMonitor struct {
 	AlertChannelSubscriptions []AlertChannelSubscription `json:"alertChannelSubscriptions,omitempty"`
 	PrivateLocations          *[]string                  `json:"privateLocations"`
 	RuntimeID                 *string                    `json:"runtimeId"`
-	RetryStrategy             *RetryStrategy             `json:"retryStrategy,omitempty"`
+	RetryStrategy             *RetryStrategy             `json:"retryStrategy"`
 	TriggerIncident           *IncidentTrigger           `json:"triggerIncident"`
 	CreatedAt                 time.Time                  `json:"created_at,omitempty"`
 	UpdatedAt                 time.Time                  `json:"updated_at,omitempty"`
@@ -774,7 +774,7 @@ type URLMonitor struct {
 	GroupOrder                int                        `json:"groupOrder,omitempty"`
 	AlertChannelSubscriptions []AlertChannelSubscription `json:"alertChannelSubscriptions,omitempty"`
 	PrivateLocations          *[]string                  `json:"privateLocations"`
-	RetryStrategy             *RetryStrategy             `json:"retryStrategy,omitempty"`
+	RetryStrategy             *RetryStrategy             `json:"retryStrategy"`
 	TriggerIncident           *IncidentTrigger           `json:"triggerIncident"`
 	CreatedAt                 time.Time                  `json:"created_at,omitempty"`
 	UpdatedAt                 time.Time                  `json:"updated_at,omitempty"`
@@ -964,7 +964,7 @@ type Group struct {
 	// Pointers
 	RuntimeID        *string        `json:"runtimeId"`
 	PrivateLocations *[]string      `json:"privateLocations"`
-	RetryStrategy    *RetryStrategy `json:"retryStrategy,omitempty"`
+	RetryStrategy    *RetryStrategy `json:"retryStrategy"`
 
 	// Deprecated: this property will be removed in future versions. Please use RetryStrategy instead.
 	DoubleCheck bool `json:"doubleCheck"`


### PR DESCRIPTION
We need to send `retryStrategy: null` to the API, but due to `omitempty` getting in the way, we exclude the entire value. This then gets further messed up by the backend's toPatchSchema helper which removes default values, making removal impossible.

## Affected Components
* [ ] New Features
* [x] Bug Fixing
* [x] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [ ] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->