### PR TITLE
feat: add support for SINGLE_RETRY retry strategy [SIM-126]

### DIFF
--- a/types.go
+++ b/types.go
@@ -939,6 +939,36 @@ type RetryStrategy struct {
 	SameRegion         bool   `json:"sameRegion"`
 }
 
+func (s RetryStrategy) MarshalJSON() ([]byte, error) {
+	type flexibleRetryStrategy struct {
+		Type               string `json:"type"`
+		BaseBackoffSeconds *int   `json:"baseBackoffSeconds,omitempty"`
+		MaxRetries         *int   `json:"maxRetries,omitempty"`
+		MaxDurationSeconds *int   `json:"maxDurationSeconds,omitempty"`
+		SameRegion         *bool  `json:"sameRegion,omitempty"`
+	}
+
+	switch s.Type {
+	case "SINGLE_RETRY":
+		// Single retries can't have MaxRetries set to 0 or backend validation
+		// will fail. We have to make sure to not send the extra properties
+		// at all.
+		return json.Marshal(flexibleRetryStrategy{
+			Type:               s.Type,
+			BaseBackoffSeconds: &s.BaseBackoffSeconds,
+			SameRegion:         &s.SameRegion,
+		})
+	default:
+		return json.Marshal(flexibleRetryStrategy{
+			Type:               s.Type,
+			BaseBackoffSeconds: &s.BaseBackoffSeconds,
+			MaxRetries:         &s.MaxRetries,
+			MaxDurationSeconds: &s.MaxDurationSeconds,
+			SameRegion:         &s.SameRegion,
+		})
+	}
+}
+
 // Group represents a check group.
 type Group struct {
 	ID                        int64                      `json:"id,omitempty"`


### PR DESCRIPTION
Technically the type was already supported (it's just a string), but we need to skip a few fields when talking with the backend to make the experience smoother.

## Affected Components
* [x] New Features
* [ ] Bug Fixing
* [x] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->