### PR TITLE
feat: add support for the RetryStrategy OnlyOn property (limit to network failures) [SIM-127]

### DIFF
--- a/types.go
+++ b/types.go
@@ -932,20 +932,22 @@ type SSLCertificates struct {
 }
 
 type RetryStrategy struct {
-	Type               string `json:"type"`
-	BaseBackoffSeconds int    `json:"baseBackoffSeconds"`
-	MaxRetries         int    `json:"maxRetries"`
-	MaxDurationSeconds int    `json:"maxDurationSeconds"`
-	SameRegion         bool   `json:"sameRegion"`
+	Type               string   `json:"type"`
+	BaseBackoffSeconds int      `json:"baseBackoffSeconds"`
+	MaxRetries         int      `json:"maxRetries"`
+	MaxDurationSeconds int      `json:"maxDurationSeconds"`
+	SameRegion         bool     `json:"sameRegion"`
+	OnlyOn             []string `json:"onlyOn,omitempty"`
 }
 
 func (s RetryStrategy) MarshalJSON() ([]byte, error) {
 	type flexibleRetryStrategy struct {
-		Type               string `json:"type"`
-		BaseBackoffSeconds *int   `json:"baseBackoffSeconds,omitempty"`
-		MaxRetries         *int   `json:"maxRetries,omitempty"`
-		MaxDurationSeconds *int   `json:"maxDurationSeconds,omitempty"`
-		SameRegion         *bool  `json:"sameRegion,omitempty"`
+		Type               string   `json:"type"`
+		BaseBackoffSeconds *int     `json:"baseBackoffSeconds,omitempty"`
+		MaxRetries         *int     `json:"maxRetries,omitempty"`
+		MaxDurationSeconds *int     `json:"maxDurationSeconds,omitempty"`
+		SameRegion         *bool    `json:"sameRegion,omitempty"`
+		OnlyOn             []string `json:"onlyOn,omitempty"`
 	}
 
 	switch s.Type {
@@ -957,6 +959,7 @@ func (s RetryStrategy) MarshalJSON() ([]byte, error) {
 			Type:               s.Type,
 			BaseBackoffSeconds: &s.BaseBackoffSeconds,
 			SameRegion:         &s.SameRegion,
+			OnlyOn:             s.OnlyOn,
 		})
 	default:
 		return json.Marshal(flexibleRetryStrategy{
@@ -965,6 +968,7 @@ func (s RetryStrategy) MarshalJSON() ([]byte, error) {
 			MaxRetries:         &s.MaxRetries,
 			MaxDurationSeconds: &s.MaxDurationSeconds,
 			SameRegion:         &s.SameRegion,
+			OnlyOn:             s.OnlyOn,
 		})
 	}
 }


### PR DESCRIPTION
This PR adds support for a new `RetryStrategy` property, `OnlyOn`. The only supported value currently is `[]string{"NETWORK_ERROR"}` which makes the retry strategy only apply on network errors.

## Affected Components
* [x] New Features
* [ ] Bug Fixing
* [x] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->