### PR TITLE
fix: make it possible to unset a check/monitor's group on update

### DIFF
--- a/checkly.go
+++ b/checkly.go
@@ -149,12 +149,41 @@ func (c *client) CreateCheck(
 	return c.createCheck(ctx, check, endpoint)
 }
 
+type checkPayload struct {
+	Check
+	GroupID *int64 `json:"groupId"`
+}
+
+func createCheckPayload(check Check) checkPayload {
+	payload := checkPayload{
+		Check: check,
+	}
+
+	// GroupID must be null if empty or the group will not get unset on update.
+	if check.GroupID != 0 {
+		payload.GroupID = &check.GroupID
+	}
+
+	// A nil value for a list will cause the backend to not update the value.
+	// We must send empty lists instead.
+	if check.Locations == nil {
+		payload.Locations = []string{}
+	}
+
+	if check.PrivateLocations == nil {
+		payload.PrivateLocations = &[]string{}
+	}
+
+	return payload
+}
+
 func (c *client) createCheck(
 	ctx context.Context,
 	check Check,
 	endpoint string,
 ) (*Check, error) {
-	data, err := json.Marshal(check)
+	payload := createCheckPayload(check)
+	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
 	}
@@ -220,18 +249,45 @@ func (c *client) CreateTCPCheck(
 	return c.CreateTCPMonitor(ctx, check)
 }
 
+type tcpMonitorPayload struct {
+	TCPMonitor
+	Type        string `json:"checkType"`
+	DoubleCheck bool   `json:"doubleCheck"`
+	GroupID     *int64 `json:"groupId"`
+}
+
+func createTCPMonitorPayload(monitor TCPMonitor) tcpMonitorPayload {
+	payload := tcpMonitorPayload{
+		TCPMonitor: monitor,
+		// Unfortunately `checkType` is required for this endpoint.
+		Type: "TCP",
+		// Unfortunately, this will default to true if not set.
+		DoubleCheck: false,
+	}
+
+	// GroupID must be null if empty or the group will not get unset on update.
+	if monitor.GroupID != 0 {
+		payload.GroupID = &monitor.GroupID
+	}
+
+	// A nil value for a list will cause the backend to not update the value.
+	// We must send empty lists instead.
+	if monitor.Locations == nil {
+		payload.Locations = []string{}
+	}
+
+	if monitor.PrivateLocations == nil {
+		payload.PrivateLocations = &[]string{}
+	}
+
+	return payload
+}
+
 func (c *client) CreateTCPMonitor(
 	ctx context.Context,
 	monitor TCPMonitor,
 ) (*TCPMonitor, error) {
-	payload := struct {
-		TCPMonitor
-		DoubleCheck bool `json:"doubleCheck"`
-	}{
-		TCPMonitor: monitor,
-		// Unfortunately, this will default to true if not set.
-		DoubleCheck: false,
-	}
+	payload := createTCPMonitorPayload(monitor)
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
@@ -255,20 +311,47 @@ func (c *client) CreateTCPMonitor(
 	return &result, nil
 }
 
+type urlMonitorPayload struct {
+	URLMonitor
+	Type        string  `json:"checkType"`
+	Request     Request `json:"request"`
+	DoubleCheck bool    `json:"doubleCheck"`
+	GroupID     *int64  `json:"groupId"`
+}
+
+func createURLMonitorPayload(monitor URLMonitor) urlMonitorPayload {
+	payload := urlMonitorPayload{
+		URLMonitor: monitor,
+		// Unfortunately `checkType` is required for this endpoint.
+		Type:    "URL",
+		Request: monitor.Request.toRequest(),
+		// Unfortunately, this will default to true if not set.
+		DoubleCheck: false,
+	}
+
+	// GroupID must be null if empty or the group will not get unset on update.
+	if monitor.GroupID != 0 {
+		payload.GroupID = &monitor.GroupID
+	}
+
+	// A nil value for a list will cause the backend to not update the value.
+	// We must send empty lists instead.
+	if monitor.Locations == nil {
+		payload.Locations = []string{}
+	}
+
+	if monitor.PrivateLocations == nil {
+		payload.PrivateLocations = &[]string{}
+	}
+
+	return payload
+}
+
 func (c *client) CreateURLMonitor(
 	ctx context.Context,
 	monitor URLMonitor,
 ) (*URLMonitor, error) {
-	payload := struct {
-		URLMonitor
-		Request     Request `json:"request"`
-		DoubleCheck bool    `json:"doubleCheck"`
-	}{
-		URLMonitor: monitor,
-		Request:    monitor.Request.toRequest(),
-		// Unfortunately, this will default to true if not set.
-		DoubleCheck: false,
-	}
+	payload := createURLMonitorPayload(monitor)
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
@@ -296,17 +379,11 @@ func (c *client) CreateURLMonitor(
 // updated check, or an error.
 func (c *client) UpdateCheck(
 	ctx context.Context,
-	ID string, check Check,
+	ID string,
+	check Check,
 ) (*Check, error) {
-	// A nil value for a list will cause the backend to not update the value.
-	// We must send empty lists instead.
-	if check.Locations == nil {
-		check.Locations = []string{}
-	}
-	if check.PrivateLocations == nil {
-		check.PrivateLocations = &[]string{}
-	}
-	data, err := json.Marshal(check)
+	payload := createCheckPayload(check)
+	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
 	}
@@ -381,26 +458,7 @@ func (c *client) UpdateTCPMonitor(
 	ID string,
 	monitor TCPMonitor,
 ) (*TCPMonitor, error) {
-	// A nil value for a list will cause the backend to not update the value.
-	// We must send empty lists instead.
-	if monitor.Locations == nil {
-		monitor.Locations = []string{}
-	}
-	if monitor.PrivateLocations == nil {
-		monitor.PrivateLocations = &[]string{}
-	}
-	payload := struct {
-		TCPMonitor
-		Type        string `json:"checkType"`
-		DoubleCheck bool   `json:"doubleCheck"`
-	}{
-		TCPMonitor: monitor,
-		// Unfortunately `checkType` is required for this endpoint, so sneak it in
-		// using an anonymous struct.
-		Type: "TCP",
-		// Unfortunately, this will default to true if not set.
-		DoubleCheck: false,
-	}
+	payload := createTCPMonitorPayload(monitor)
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
@@ -430,28 +488,7 @@ func (c *client) UpdateURLMonitor(
 	ID string,
 	monitor URLMonitor,
 ) (*URLMonitor, error) {
-	// A nil value for a list will cause the backend to not update the value.
-	// We must send empty lists instead.
-	if monitor.Locations == nil {
-		monitor.Locations = []string{}
-	}
-	if monitor.PrivateLocations == nil {
-		monitor.PrivateLocations = &[]string{}
-	}
-	// Unfortunately `checkType` is required for this endpoint, so sneak it in
-	// using an anonymous struct.
-	payload := struct {
-		URLMonitor
-		Type        string  `json:"checkType"`
-		Request     Request `json:"request"`
-		DoubleCheck bool    `json:"doubleCheck"`
-	}{
-		URLMonitor: monitor,
-		Type:       "URL",
-		Request:    monitor.Request.toRequest(),
-		// Unfortunately, this will default to true if not set.
-		DoubleCheck: false,
-	}
+	payload := createURLMonitorPayload(monitor)
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
@@ -638,13 +675,36 @@ func (c *client) GetURLMonitor(
 	return &result, nil
 }
 
+type groupPayload struct {
+	Group
+}
+
+func createGroupPayload(group Group) groupPayload {
+	payload := groupPayload{
+		Group: group,
+	}
+
+	// A nil value for a list will cause the backend to not update the value.
+	// We must send empty lists instead.
+	if group.Locations == nil {
+		payload.Locations = []string{}
+	}
+
+	if group.PrivateLocations == nil {
+		payload.PrivateLocations = &[]string{}
+	}
+
+	return payload
+}
+
 // CreateGroup creates a new check group with the specified details. It returns
 // the newly-created group, or an error.
 func (c *client) CreateGroup(
 	ctx context.Context,
 	group Group,
 ) (*Group, error) {
-	data, err := json.Marshal(group)
+	payload := createGroupPayload(group)
+	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
 	}
@@ -702,15 +762,8 @@ func (c *client) UpdateGroup(
 	ID int64,
 	group Group,
 ) (*Group, error) {
-	// A nil value for a list will cause the backend to not update the value.
-	// We must send empty lists instead.
-	if group.Locations == nil {
-		group.Locations = []string{}
-	}
-	if group.PrivateLocations == nil {
-		group.PrivateLocations = &[]string{}
-	}
-	data, err := json.Marshal(group)
+	payload := createGroupPayload(group)
+	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
 	}

--- a/checkly_integration_test.go
+++ b/checkly_integration_test.go
@@ -55,6 +55,79 @@ func TestCreateIntegration(t *testing.T) {
 	}
 }
 
+func TestCheckGroupUnset(t *testing.T) {
+	ctx := context.TODO()
+
+	client := setupClient(t)
+
+	group, err := client.CreateGroup(ctx, checkly.Group{
+		Name:        "Test Group",
+		Concurrency: 3,
+		Tags:        []string{},
+		AlertSettings: checkly.AlertSettings{
+			EscalationType: checkly.RunBased,
+			RunBasedEscalation: checkly.RunBasedEscalation{
+				FailedRunThreshold: 1,
+			},
+		},
+		Locations: []string{"us-east-1"},
+	})
+
+	if err != nil {
+		t.Fatalf("failed to create group for check: %v", err)
+	}
+
+	defer func() {
+		_ = client.DeleteGroup(ctx, group.ID)
+	}()
+
+	pendingCheck := checkly.Check{
+		Name:      "Foo check",
+		Type:      checkly.TypeAPI,
+		Frequency: 10,
+		Request: checkly.Request{
+			Method:          "GET",
+			URL:             "https://api.checklyhq.com",
+			Headers:         []checkly.KeyValue{},
+			QueryParameters: []checkly.KeyValue{},
+			Assertions:      []checkly.Assertion{},
+		},
+		AlertSettings: checkly.AlertSettings{
+			EscalationType: checkly.RunBased,
+			RunBasedEscalation: checkly.RunBasedEscalation{
+				FailedRunThreshold: 1,
+			},
+		},
+		Locations: []string{"us-east-1"},
+		GroupID:   group.ID,
+	}
+
+	createdCheck, err := client.CreateCheck(ctx, pendingCheck)
+	if err != nil {
+		t.Fatalf("failed to create check: %v", err)
+	}
+
+	defer func() {
+		_ = client.DeleteTCPMonitor(ctx, createdCheck.ID)
+	}()
+
+	if createdCheck.GroupID != group.ID {
+		t.Fatalf("wrong GroupID after creation")
+	}
+
+	updateCheck := pendingCheck
+	updateCheck.GroupID = 0
+
+	updatedCheck, err := client.UpdateCheck(ctx, createdCheck.ID, updateCheck)
+	if err != nil {
+		t.Fatalf("failed to update check: %v", err)
+	}
+
+	if updatedCheck.GroupID != 0 {
+		t.Fatalf("wrong GroupID after update")
+	}
+}
+
 func TestGetIntegration(t *testing.T) {
 	client := setupClient(t)
 	check, err := client.Create(context.Background(), wantCheck)
@@ -380,6 +453,68 @@ func TestTCPCheckCRUD(t *testing.T) {
 	}
 }
 
+func TestTCPMonitorGroupUnset(t *testing.T) {
+	ctx := context.TODO()
+
+	client := setupClient(t)
+
+	group, err := client.CreateGroup(ctx, checkly.Group{
+		Name:        "Test Group",
+		Concurrency: 3,
+		Tags:        []string{},
+		AlertSettings: checkly.AlertSettings{
+			EscalationType: checkly.RunBased,
+			RunBasedEscalation: checkly.RunBasedEscalation{
+				FailedRunThreshold: 1,
+			},
+		},
+		Locations: []string{"us-east-1"},
+	})
+
+	if err != nil {
+		t.Fatalf("failed to create group for TCP monitor: %v", err)
+	}
+
+	defer func() {
+		_ = client.DeleteGroup(ctx, group.ID)
+	}()
+
+	pendingMonitor := checkly.TCPMonitor{
+		Name: "Foo monitor",
+		Request: checkly.TCPRequest{
+			Hostname: "api.checklyhq.com",
+			Port:     443,
+		},
+		Locations: []string{"us-east-1"},
+		GroupID:   group.ID,
+	}
+
+	createdMonitor, err := client.CreateTCPMonitor(ctx, pendingMonitor)
+	if err != nil {
+		t.Fatalf("failed to create TCP monitor: %v", err)
+	}
+
+	defer func() {
+		_ = client.DeleteTCPMonitor(ctx, createdMonitor.ID)
+	}()
+
+	if createdMonitor.GroupID != group.ID {
+		t.Fatalf("wrong GroupID after creation")
+	}
+
+	updateMonitor := pendingMonitor
+	updateMonitor.GroupID = 0
+
+	updatedMonitor, err := client.UpdateTCPMonitor(ctx, createdMonitor.ID, updateMonitor)
+	if err != nil {
+		t.Fatalf("failed to update TCP monitor: %v", err)
+	}
+
+	if updatedMonitor.GroupID != 0 {
+		t.Fatalf("wrong GroupID after update")
+	}
+}
+
 func TestClientCertificateCRD(t *testing.T) {
 	ctx := context.TODO()
 
@@ -636,4 +771,66 @@ func TestURLMonitorCRUD(t *testing.T) {
 			t.Fatalf("failed to delete URL monitor: %v", err)
 		}
 	})
+}
+
+func TestURLMonitorGroupUnset(t *testing.T) {
+	ctx := context.TODO()
+
+	client := setupClient(t)
+
+	group, err := client.CreateGroup(ctx, checkly.Group{
+		Name:        "Test Group",
+		Concurrency: 3,
+		Tags:        []string{},
+		AlertSettings: checkly.AlertSettings{
+			EscalationType: checkly.RunBased,
+			RunBasedEscalation: checkly.RunBasedEscalation{
+				FailedRunThreshold: 1,
+			},
+		},
+		Locations: []string{"us-east-1"},
+	})
+
+	if err != nil {
+		t.Fatalf("failed to create group for URL monitor: %v", err)
+	}
+
+	defer func() {
+		_ = client.DeleteGroup(ctx, group.ID)
+	}()
+
+	pendingMonitor := checkly.URLMonitor{
+		Name: "Foo monitor",
+		Request: checkly.URLRequest{
+			URL:        "https://welcome.checklyhq.com/foo",
+			Assertions: []checkly.Assertion{},
+		},
+		Locations: []string{"us-east-1"},
+		GroupID:   group.ID,
+	}
+
+	createdMonitor, err := client.CreateURLMonitor(ctx, pendingMonitor)
+	if err != nil {
+		t.Fatalf("failed to create URL monitor: %v", err)
+	}
+
+	defer func() {
+		_ = client.DeleteURLMonitor(ctx, createdMonitor.ID)
+	}()
+
+	if createdMonitor.GroupID != group.ID {
+		t.Fatalf("wrong GroupID after creation")
+	}
+
+	updateMonitor := pendingMonitor
+	updateMonitor.GroupID = 0
+
+	updatedMonitor, err := client.UpdateURLMonitor(ctx, createdMonitor.ID, updateMonitor)
+	if err != nil {
+		t.Fatalf("failed to update URL monitor: %v", err)
+	}
+
+	if updatedMonitor.GroupID != 0 {
+		t.Fatalf("wrong GroupID after update")
+	}
 }


### PR DESCRIPTION
This PR adds a workaround for a yet another problem with the API. When updating checks/monitors, if the `groupId` is not explicitly set to `null` (vs leaving it out of the payload entirely), the check will not get unassigned from the group.

A slight breaking change is introduced. Before, if you intended to not update the group (i.e. leave it as is), you could just not set the `GroupID` and it would work. However, that's not how the SDK is intended to be used.

## Affected Components
* [ ] New Features
* [x] Bug Fixing
* [ ] Types
* [x] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->