### PR TITLE
feat: add Description field to StatusPage struct [SP-124]

### DIFF
--- a/types.go
+++ b/types.go
@@ -1539,6 +1539,9 @@ type StatusPage struct {
 	// Name is the name of the status page.
 	Name string `json:"name"`
 
+	// Description is an optional introductory description. Maximum 500 characters.
+	Description string `json:"description,omitempty"`
+
 	// URL is the unique subdomain of the status page.
 	URL string `json:"url"`
 


### PR DESCRIPTION
## Summary
- Add optional `Description` field to `StatusPage` struct (max 500 chars, omitempty)

resolves SP-124

## Test plan
- [ ] Verify status page creation with description via SDK
- [ ] Verify description is returned when fetching status pages