### PR TITLE
feat: add check groups v2 support

### DIFF
--- a/checkly.go
+++ b/checkly.go
@@ -1100,6 +1100,60 @@ func (c *client) CreateGroup(
 	return &result, nil
 }
 
+type groupV2Payload struct {
+	GroupV2
+}
+
+func createGroupV2Payload(group GroupV2) groupV2Payload {
+	payload := groupV2Payload{
+		GroupV2: group,
+	}
+
+	// A nil value for a list will cause the backend to not update the value.
+	// We must send empty lists instead.
+	if group.Locations == nil {
+		payload.Locations = []string{}
+	}
+
+	if group.PrivateLocations == nil {
+		payload.PrivateLocations = &[]string{}
+	}
+
+	return payload
+}
+
+// CreateGroupV2 creates a new check group with the specified details. It returns
+// the newly-created group, or an error.
+func (c *client) CreateGroupV2(
+	ctx context.Context,
+	group GroupV2,
+) (*GroupV2, error) {
+	payload := createGroupV2Payload(group)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	status, res, err := c.apiCallV(
+		ctx,
+		2,
+		http.MethodPost,
+		withAutoAssignAlertsFlag("check-groups"),
+		data,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result GroupV2
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
 // GetGroup takes the ID of an existing check group, and returns the
 // corresponding group, or an error.
 func (c *client) GetGroup(
@@ -1119,6 +1173,33 @@ func (c *client) GetGroup(
 		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
 	}
 	result := Group{}
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %q: %v", res, err)
+	}
+	return &result, nil
+}
+
+// GetGroupV2 takes the ID of an existing check group, and returns the
+// corresponding group, or an error.
+func (c *client) GetGroupV2(
+	ctx context.Context,
+	ID int64,
+) (*GroupV2, error) {
+	status, res, err := c.apiCallV(
+		ctx,
+		1,
+		http.MethodGet,
+		fmt.Sprintf("check-groups/%d", ID),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result GroupV2
 	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
 	if err != nil {
 		return nil, fmt.Errorf("decoding error for data %q: %v", res, err)
@@ -1159,6 +1240,40 @@ func (c *client) UpdateGroup(
 	return &result, nil
 }
 
+// UpdateGroupV2 takes the ID of an existing check group, and updates the
+// corresponding check group to match the supplied group. It returns the updated
+// group, or an error.
+func (c *client) UpdateGroupV2(
+	ctx context.Context,
+	ID int64,
+	group GroupV2,
+) (*GroupV2, error) {
+	payload := createGroupV2Payload(group)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	status, res, err := c.apiCallV(
+		ctx,
+		2,
+		http.MethodPut,
+		withAutoAssignAlertsFlag(fmt.Sprintf("check-groups/%d", ID)),
+		data,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result GroupV2
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
 // DeleteGroup deletes the check group with the specified ID.
 func (c *client) DeleteGroup(
 	ctx context.Context,
@@ -1177,6 +1292,14 @@ func (c *client) DeleteGroup(
 		return fmt.Errorf("unexpected response status %d: %q", status, res)
 	}
 	return nil
+}
+
+// DeleteGroupV2 deletes the check group with the specified ID.
+func (c *client) DeleteGroupV2(
+	ctx context.Context,
+	ID int64,
+) error {
+	return c.DeleteGroup(ctx, ID)
 }
 
 // GetCheckResult gets a specific Check result
@@ -2387,7 +2510,26 @@ func (c *client) apiCall(
 	URL string,
 	data []byte,
 ) (statusCode int, response string, err error) {
-	requestURL := c.url + "/v1/" + URL
+	return c.apiCallV1(ctx, method, URL, data)
+}
+
+func (c *client) apiCallV1(
+	ctx context.Context,
+	method string,
+	URL string,
+	data []byte,
+) (statusCode int, response string, err error) {
+	return c.apiCallV(ctx, 1, method, URL, data)
+}
+
+func (c *client) apiCallV(
+	ctx context.Context,
+	v int,
+	method string,
+	URL string,
+	data []byte,
+) (statusCode int, response string, err error) {
+	requestURL := fmt.Sprintf("%s/v%d/%s", c.url, v, URL)
 	req, err := http.NewRequest(method, requestURL, bytes.NewBuffer(data))
 
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -302,12 +302,26 @@ type Client interface {
 		group Group,
 	) (*Group, error)
 
+	// CreateGroupV2 creates a new check group with the specified details.
+	// It returns the newly-created group, or an error.
+	CreateGroupV2(
+		ctx context.Context,
+		group GroupV2,
+	) (*GroupV2, error)
+
 	// GetGroup takes the ID of an existing check group, and returns the
 	// corresponding group, or an error.
 	GetGroup(
 		ctx context.Context,
 		ID int64,
 	) (*Group, error)
+
+	// GetGroupV2 takes the ID of an existing check group, and returns the
+	// corresponding group, or an error.
+	GetGroupV2(
+		ctx context.Context,
+		ID int64,
+	) (*GroupV2, error)
 
 	// UpdateGroup takes the ID of an existing check group, and updates the
 	// corresponding check group to match the supplied group. It returns the updated
@@ -318,8 +332,23 @@ type Client interface {
 		group Group,
 	) (*Group, error)
 
+	// UpdateGroupV2 takes the ID of an existing check group, and updates the
+	// corresponding check group to match the supplied group. It returns the updated
+	// group, or an error.
+	UpdateGroupV2(
+		ctx context.Context,
+		ID int64,
+		group GroupV2,
+	) (*GroupV2, error)
+
 	// DeleteGroup deletes the check group with the specified ID. It returns a
 	DeleteGroup(
+		ctx context.Context,
+		ID int64,
+	) error
+
+	// DeleteGroupV2 deletes the check group with the specified ID. It returns a
+	DeleteGroupV2(
 		ctx context.Context,
 		ID int64,
 	) error
@@ -1126,6 +1155,10 @@ func (s RetryStrategy) MarshalJSON() ([]byte, error) {
 			SameRegion:         &s.SameRegion,
 			OnlyOn:             s.OnlyOn,
 		})
+	case "NO_RETRIES":
+		return json.Marshal(nil)
+	case "FALLBACK":
+		return json.Marshal("FALLBACK")
 	default:
 		return json.Marshal(flexibleRetryStrategy{
 			Type:               s.Type,
@@ -1136,6 +1169,38 @@ func (s RetryStrategy) MarshalJSON() ([]byte, error) {
 			OnlyOn:             s.OnlyOn,
 		})
 	}
+}
+
+func (s *RetryStrategy) UnmarshalJSON(data []byte) error {
+	// Clear all fields so previous values don't leak through.
+	*s = RetryStrategy{}
+
+	// null -> NO_RETRIES (reverse of MarshalJSON which emits null for NO_RETRIES)
+	if string(data) == "null" {
+		s.Type = "NO_RETRIES"
+		return nil
+	}
+
+	// Plain string -> FALLBACK
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		if str != "FALLBACK" {
+			return fmt.Errorf("Unsupported value %q for retry strategy", str)
+		}
+		s.Type = str
+		return nil
+	}
+
+	// Object -> standard unmarshal. Use an alias type to avoid infinite
+	// recursion: the alias has the same fields but no UnmarshalJSON method,
+	// so json.Unmarshal uses the default struct decoder.
+	type retryStrategyAlias RetryStrategy
+	var alias retryStrategyAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*s = RetryStrategy(alias)
+	return nil
 }
 
 // Group represents a check group.
@@ -1167,6 +1232,32 @@ type Group struct {
 
 	// Deprecated: this property will be removed in future versions. Please use RetryStrategy instead.
 	DoubleCheck bool `json:"doubleCheck"`
+}
+
+// Group represents a check group v2.
+type GroupV2 struct {
+	ID                        int64                      `json:"id,omitempty"`
+	Name                      string                     `json:"name"`
+	Activated                 bool                       `json:"activated"`
+	Muted                     bool                       `json:"muted"`
+	RunParallel               *bool                      `json:"runParallel"`
+	Tags                      []string                   `json:"tags"`
+	Locations                 []string                   `json:"locations"`
+	Concurrency               int                        `json:"concurrency"`
+	APICheckDefaults          APICheckDefaults           `json:"apiCheckDefaults"`
+	EnvironmentVariables      []EnvironmentVariable      `json:"environmentVariables"`
+	UseGlobalAlertSettings    *bool                      `json:"useGlobalAlertSettings"`
+	AlertSettings             *AlertSettings             `json:"alertSettings"`
+	SetupSnippetID            *int64                     `json:"setupSnippetId"`
+	TearDownSnippetID         *int64                     `json:"tearDownSnippetId"`
+	LocalSetupScript          *string                    `json:"localSetupScript"`
+	LocalTearDownScript       *string                    `json:"localTearDownScript"`
+	AlertChannelSubscriptions []AlertChannelSubscription `json:"alertChannelSubscriptions,omitempty"`
+	RuntimeID                 *string                    `json:"runtimeId"`
+	PrivateLocations          *[]string                  `json:"privateLocations"`
+	RetryStrategy             *RetryStrategy             `json:"retryStrategy"`
+	CreatedAt                 time.Time                  `json:"createdAt"`
+	UpdatedAt                 time.Time                  `json:"updatedAt"`
 }
 
 // APICheckDefaults represents the default settings for API checks within a

--- a/types_test.go
+++ b/types_test.go
@@ -1,6 +1,8 @@
 package checkly_test
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 
 	checkly "github.com/checkly/checkly-go-sdk"
@@ -321,6 +323,104 @@ func TestAlertChannelOpsgenie(t *testing.T) {
 			cfg.Priority,
 			ac.Opsgenie.Priority,
 		)
+	}
+}
+
+func TestRetryStrategyRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		input checkly.RetryStrategy
+		want  checkly.RetryStrategy
+	}{
+		{
+			name:  "FIXED strategy round-trips",
+			input: checkly.RetryStrategy{Type: "FIXED", MaxRetries: 2, MaxDurationSeconds: 600, BaseBackoffSeconds: 60, SameRegion: true},
+			want:  checkly.RetryStrategy{Type: "FIXED", MaxRetries: 2, MaxDurationSeconds: 600, BaseBackoffSeconds: 60, SameRegion: true},
+		},
+		{
+			name:  "LINEAR strategy round-trips",
+			input: checkly.RetryStrategy{Type: "LINEAR", MaxRetries: 3, MaxDurationSeconds: 300, BaseBackoffSeconds: 30, SameRegion: false},
+			want:  checkly.RetryStrategy{Type: "LINEAR", MaxRetries: 3, MaxDurationSeconds: 300, BaseBackoffSeconds: 30, SameRegion: false},
+		},
+		{
+			name:  "SINGLE_RETRY omits MaxRetries and MaxDurationSeconds",
+			input: checkly.RetryStrategy{Type: "SINGLE_RETRY", BaseBackoffSeconds: 10, SameRegion: true},
+			want:  checkly.RetryStrategy{Type: "SINGLE_RETRY", BaseBackoffSeconds: 10, SameRegion: true},
+		},
+		{
+			name:  "NO_RETRIES marshals as null and back",
+			input: checkly.RetryStrategy{Type: "NO_RETRIES"},
+			want:  checkly.RetryStrategy{Type: "NO_RETRIES"},
+		},
+		{
+			name:  "FALLBACK marshals as string and back",
+			input: checkly.RetryStrategy{Type: "FALLBACK"},
+			want:  checkly.RetryStrategy{Type: "FALLBACK"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.input)
+			if err != nil {
+				t.Fatalf("Marshal error: %v", err)
+			}
+			var got checkly.RetryStrategy
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Unmarshal error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %+v, want %+v (JSON was: %s)", got, tt.want, data)
+			}
+		})
+	}
+}
+
+func TestRetryStrategyUnmarshalClearsFields(t *testing.T) {
+	// Unmarshal into a struct that already has values to verify fields are cleared.
+	s := checkly.RetryStrategy{
+		Type:               "FIXED",
+		MaxRetries:         5,
+		MaxDurationSeconds: 600,
+		BaseBackoffSeconds: 60,
+		SameRegion:         true,
+	}
+	if err := json.Unmarshal([]byte("null"), &s); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	want := checkly.RetryStrategy{Type: "NO_RETRIES"}
+	if !reflect.DeepEqual(s, want) {
+		t.Errorf("got %+v, want %+v", s, want)
+	}
+}
+
+func TestRetryStrategyUnmarshalRejectsUnknownString(t *testing.T) {
+	var s checkly.RetryStrategy
+	err := json.Unmarshal([]byte(`"UNKNOWN"`), &s)
+	if err == nil {
+		t.Fatal("expected error for unknown string value, got nil")
+	}
+}
+
+func TestRetryStrategyMarshalNoRetries(t *testing.T) {
+	s := checkly.RetryStrategy{Type: "NO_RETRIES"}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	if string(data) != "null" {
+		t.Errorf("got %s, want null", data)
+	}
+}
+
+func TestRetryStrategyMarshalFallback(t *testing.T) {
+	s := checkly.RetryStrategy{Type: "FALLBACK"}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	if string(data) != `"FALLBACK"` {
+		t.Errorf("got %s, want %q", data, "FALLBACK")
 	}
 }
 


### PR DESCRIPTION
## Affected Components
* [x] New Features
* [ ] Bug Fixing
* [x] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Notes for the Reviewer
<!-- Anything the reviewer should pay extra attention to. -->

This PR adds the required types for Groups V2 support. 

Notably, a slightly breaking change is introduced: the SDK now changes the NO_RETRIES retry strategy, which was previously just `nil`, to `RetryStrategy { Type: "NO_RETRIES" }`. This is marshaled to `nil` when marshaling JSON, and `nil` is unmarshaled into `RetryStrategy { Type: "NO_RETRIES" }` as well. However, given that this poor man's SDK is only used by our Terraform provider, it should not be a huge deal.

> Resolves #[issue-number]

## New Dependency Submission
<!-- Please explain here why we need the new dependency. -->