### PR TITLE
Add Engine and EngineVersion fields to PlaywrightCheck [RED-515]

### DIFF
--- a/types.go
+++ b/types.go
@@ -1733,6 +1733,8 @@ type PlaywrightCheck struct {
 	Browsers          []string `json:"browsers"`
 	CodeBundlePath    string   `json:"codeBundlePath"`
 	WorkingDir        *string  `json:"workingDir"`
+	Engine            *string  `json:"engine"`
+	EngineVersion     *string  `json:"engineVersion"`
 
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	UpdatedAt time.Time `json:"updated_at,omitempty"`


### PR DESCRIPTION
## Summary

- Adds `Engine *string` and `EngineVersion *string` fields to the `PlaywrightCheck` struct
- JSON tags: `"engine"` and `"engineVersion"` (no omitempty, matches API contract)
- Fields flow automatically through create/update payloads via the embedded `playwrightCheckPayload`

This enables the Terraform provider to send engine selection (`node`/`bun` + version) to the Checkly API for Playwright Check Suites.

## Depends on / Related

- **Backend:** checkly/monorepo `feat/multi-engine-version-support` (engine/engineVersion fields on checks)
- **Provider:** checkly/terraform-provider-checkly `simo/red-515-terraform-allows-pwcs-runtime-engine-to-be-selected` (consumes these fields)