### PR TITLE
feat: adds slack app alert channel

### DIFF
--- a/types.go
+++ b/types.go
@@ -1325,8 +1325,13 @@ type Snippet struct {
 }
 
 const (
-	AlertTypeEmail     = "EMAIL"
-	AlertTypeSlack     = "SLACK"
+	AlertTypeEmail = "EMAIL"
+
+	// AlertTypeSlack identifies legacy Slack webhook alert channels.
+	//
+	// Deprecated: Use [AlertTypeSlackApp] instead.
+	AlertTypeSlack = "SLACK"
+
 	AlertTypeSlackApp  = "SLACK_APP"
 	AlertTypeWebhook   = "WEBHOOK"
 	AlertTypeSMS       = "SMS"
@@ -1346,7 +1351,10 @@ type AlertChannelEmail struct {
 	Address string `json:"address"`
 }
 
-// AlertChannelSlack defines a type for a slack alert channel
+// AlertChannelSlack defines a type for a slack alert channel.
+//
+// Deprecated: Use [AlertChannelSlackApp] instead. The legacy Slack webhook
+// integration is being phased out in favor of the Checkly Slack App.
 type AlertChannelSlack struct {
 	WebhookURL string `json:"url"`
 	Channel    string `json:"channel"`

--- a/types.go
+++ b/types.go
@@ -1327,6 +1327,7 @@ type Snippet struct {
 const (
 	AlertTypeEmail     = "EMAIL"
 	AlertTypeSlack     = "SLACK"
+	AlertTypeSlackApp  = "SLACK_APP"
 	AlertTypeWebhook   = "WEBHOOK"
 	AlertTypeSMS       = "SMS"
 	AlertTypePagerduty = "PAGERDUTY"
@@ -1349,6 +1350,22 @@ type AlertChannelEmail struct {
 type AlertChannelSlack struct {
 	WebhookURL string `json:"url"`
 	Channel    string `json:"channel"`
+}
+
+// AlertChannelSlackApp defines a type for a Slack App alert channel. It targets
+// one or more Slack channels via the Checkly Slack App. SlackChannels must
+// contain at least one entry.
+type AlertChannelSlackApp struct {
+	SlackChannels []string `json:"slackChannels"`
+}
+
+// MarshalJSON enforces that SlackChannels is non-empty.
+func (a AlertChannelSlackApp) MarshalJSON() ([]byte, error) {
+	if len(a.SlackChannels) == 0 {
+		return nil, fmt.Errorf("AlertChannelSlackApp: slackChannels must contain at least one channel")
+	}
+	type alias AlertChannelSlackApp
+	return json.Marshal(alias(a))
 }
 
 // AlertChannelSMS defines a type for a sms alert channel
@@ -1397,6 +1414,7 @@ type AlertChannel struct {
 	Type               string                 `json:"type"`
 	Email              *AlertChannelEmail     `json:"-"`
 	Slack              *AlertChannelSlack     `json:"-"`
+	SlackApp           *AlertChannelSlackApp  `json:"-"`
 	SMS                *AlertChannelSMS       `json:"-"`
 	CALL               *AlertChannelCall      `json:"-"`
 	Opsgenie           *AlertChannelOpsgenie  `json:"-"`
@@ -1524,6 +1542,8 @@ func (a *AlertChannel) SetConfig(cfg interface{}) {
 		a.CALL = cfg.(*AlertChannelCall)
 	case *AlertChannelSlack:
 		a.Slack = cfg.(*AlertChannelSlack)
+	case *AlertChannelSlackApp:
+		a.SlackApp = cfg.(*AlertChannelSlackApp)
 	case *AlertChannelWebhook:
 		a.Webhook = cfg.(*AlertChannelWebhook)
 	case *AlertChannelOpsgenie:
@@ -1548,6 +1568,8 @@ func (a *AlertChannel) GetConfig() (cfg map[string]interface{}) {
 		byts, err = json.Marshal(a.CALL)
 	case AlertTypeSlack:
 		byts, err = json.Marshal(a.Slack)
+	case AlertTypeSlackApp:
+		byts, err = json.Marshal(a.SlackApp)
 	case AlertTypeOpsgenie:
 		byts, err = json.Marshal(a.Opsgenie)
 	case AlertTypePagerduty:
@@ -1580,6 +1602,10 @@ func AlertChannelConfigFromJSON(channelType string, cfgJSON []byte) (interface{}
 		return &r, nil
 	case AlertTypeSlack:
 		r := AlertChannelSlack{}
+		json.Unmarshal(cfgJSON, &r)
+		return &r, nil
+	case AlertTypeSlackApp:
+		r := AlertChannelSlackApp{}
 		json.Unmarshal(cfgJSON, &r)
 		return &r, nil
 	case AlertTypeOpsgenie:

--- a/types.go
+++ b/types.go
@@ -1367,15 +1367,6 @@ type AlertChannelSlackApp struct {
 	SlackChannels []string `json:"slackChannels"`
 }
 
-// MarshalJSON enforces that SlackChannels is non-empty.
-func (a AlertChannelSlackApp) MarshalJSON() ([]byte, error) {
-	if len(a.SlackChannels) == 0 {
-		return nil, fmt.Errorf("AlertChannelSlackApp: slackChannels must contain at least one channel")
-	}
-	type alias AlertChannelSlackApp
-	return json.Marshal(alias(a))
-}
-
 // AlertChannelSMS defines a type for a sms alert channel
 type AlertChannelSMS struct {
 	Name   string `json:"name"`

--- a/types_test.go
+++ b/types_test.go
@@ -98,20 +98,6 @@ func TestAlertChannelSlackApp(t *testing.T) {
 	}
 }
 
-func TestAlertChannelSlackAppRejectsEmptyChannels(t *testing.T) {
-	cases := map[string]checkly.AlertChannelSlackApp{
-		"nil slice":   {},
-		"empty slice": {SlackChannels: []string{}},
-	}
-	for name, cfg := range cases {
-		t.Run(name, func(t *testing.T) {
-			if _, err := json.Marshal(cfg); err == nil {
-				t.Error("Expected error when marshaling SlackApp with empty SlackChannels, got nil")
-			}
-		})
-	}
-}
-
 func TestAlertChannelSlackAppConfigFromJSON(t *testing.T) {
 	raw := []byte(`{"slackChannels":["C123","C456"]}`)
 	v, err := checkly.AlertChannelConfigFromJSON(checkly.AlertTypeSlackApp, raw)

--- a/types_test.go
+++ b/types_test.go
@@ -65,6 +65,71 @@ func TestAlertChannelSlack(t *testing.T) {
 	}
 }
 
+func TestAlertChannelSlackApp(t *testing.T) {
+	ac := checkly.AlertChannel{
+		Type: checkly.AlertTypeSlackApp,
+	}
+	cfg := checkly.AlertChannelSlackApp{
+		SlackChannels: []string{"#ops", "@John"},
+	}
+
+	ac.SetConfig(&cfg)
+
+	if ac.SlackApp == nil {
+		t.Error("Config shouldn't be nil")
+		return
+	}
+
+	if !reflect.DeepEqual(ac.SlackApp.SlackChannels, cfg.SlackChannels) {
+		t.Errorf(
+			"Expected: %v, got: %v",
+			cfg.SlackChannels,
+			ac.SlackApp.SlackChannels,
+		)
+	}
+
+	got := ac.GetConfig()
+	channels, ok := got["slackChannels"].([]interface{})
+	if !ok {
+		t.Fatalf("Expected slackChannels in config, got: %v", got)
+	}
+	if len(channels) != 2 || channels[0] != "#ops" || channels[1] != "@John" {
+		t.Errorf("Unexpected slackChannels: %v", channels)
+	}
+}
+
+func TestAlertChannelSlackAppRejectsEmptyChannels(t *testing.T) {
+	cases := map[string]checkly.AlertChannelSlackApp{
+		"nil slice":   {},
+		"empty slice": {SlackChannels: []string{}},
+	}
+	for name, cfg := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := json.Marshal(cfg); err == nil {
+				t.Error("Expected error when marshaling SlackApp with empty SlackChannels, got nil")
+			}
+		})
+	}
+}
+
+func TestAlertChannelSlackAppConfigFromJSON(t *testing.T) {
+	raw := []byte(`{"slackChannels":["C123","C456"]}`)
+	v, err := checkly.AlertChannelConfigFromJSON(checkly.AlertTypeSlackApp, raw)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	got, ok := v.(*checkly.AlertChannelSlackApp)
+	if !ok {
+		t.Fatalf("Expected *AlertChannelSlackApp, got %T", v)
+	}
+	want := &checkly.AlertChannelSlackApp{
+		SlackChannels: []string{"C123", "C456"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
 func TestAlertChannelSMS(t *testing.T) {
 	ac := checkly.AlertChannel{
 		Type: checkly.AlertTypeSMS,


### PR DESCRIPTION
## Affected Components
* [x] New Features
* [ ] Bug Fixing
* [ ] Types
* [ ] Tests
* [ ] Docs
* [ ] Other

## Style
* [x] Go code is formatted with `go fmt`

## Notes for the Reviewer

Adds the types and tests for creating a SLACK_APP alert channel