### PR TITLE
feat: add gRPC SSL and traceroute monitor types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <br>
 
+## [Unreleased]
+### Added
+- Add SSL assertion grammar: new assertion sources `CERTIFICATE`, `CONNECTION`, `RESPONSE_TIME`, `JSON_RESPONSE` and `TEXT_RESPONSE`, plus `IS_NULL`/`NOT_NULL` comparisons
+
 ## [v1.22.0](https://github.com/checkly/checkly-go-sdk/releases/tag/v1.22.0) - 2026-06-25
 ### Added
 - Add `GRPCMonitor` type + `Create/Get/Update/Delete` client methods (`checks/grpc`) [#c0f841a](https://github.com/checkly/checkly-go-sdk/commit/c0f841a)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <br>
 
+## [v1.22.0](https://github.com/checkly/checkly-go-sdk/releases/tag/v1.22.0) - 2026-06-25
+### Added
+- Add `GRPCMonitor` type + `Create/Get/Update/Delete` client methods (`checks/grpc`) [#c0f841a](https://github.com/checkly/checkly-go-sdk/commit/c0f841a)
+- Add `TracerouteMonitor` type + `Create/Get/Update/Delete` client methods (`checks/traceroute`) [#85860b0](https://github.com/checkly/checkly-go-sdk/commit/85860b0)
+- Add `SSLMonitor` type + `Create/Get/Update/Delete` client methods (`checks/ssl`) [#e30a577](https://github.com/checkly/checkly-go-sdk/commit/e30a577)
+
 ## [v1.6.1](https://github.com/checkly/checkly-go-sdk/releases/tag/v1.6.1) - 2022-06-22
 ### Added
 - Allow check/group private location assigments using pointers [#90d4a59](https://github.com/checkly/checkly-go-sdk/commit/90d4a598596329a22c413b10b12b74673c337bfd)

--- a/checkly.go
+++ b/checkly.go
@@ -153,6 +153,8 @@ func (c *client) CreateCheck(
 		return nil, fmt.Errorf("user error: use CreateGRPCMonitor to create GRPC monitors")
 	case "TRACEROUTE":
 		return nil, fmt.Errorf("user error: use CreateTracerouteMonitor to create TRACEROUTE monitors")
+	case "SSL":
+		return nil, fmt.Errorf("user error: use CreateSSLMonitor to create SSL monitors")
 	default:
 		return nil, fmt.Errorf("unknown check type: %s", check.Type)
 	}
@@ -440,6 +442,68 @@ func (c *client) CreateTracerouteMonitor(
 		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
 	}
 	var result TracerouteMonitor
+	if err = json.NewDecoder(strings.NewReader(res)).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
+type sslMonitorPayload struct {
+	SSLMonitor
+	Type        string `json:"checkType"`
+	DoubleCheck bool   `json:"doubleCheck"`
+	GroupID     *int64 `json:"groupId"`
+}
+
+func createSSLMonitorPayload(monitor SSLMonitor) sslMonitorPayload {
+	payload := sslMonitorPayload{
+		SSLMonitor: monitor,
+		// Unfortunately `checkType` is required for this endpoint.
+		Type: "SSL",
+		// Unfortunately, this will default to true if not set.
+		DoubleCheck: false,
+	}
+
+	// GroupID must be null if empty or the group will not get unset on update.
+	if monitor.GroupID != 0 {
+		payload.GroupID = &monitor.GroupID
+	}
+
+	// A nil value for a list will cause the backend to not update the value.
+	// We must send empty lists instead.
+	if monitor.Locations == nil {
+		payload.Locations = []string{}
+	}
+
+	if monitor.PrivateLocations == nil {
+		payload.PrivateLocations = &[]string{}
+	}
+
+	return payload
+}
+
+func (c *client) CreateSSLMonitor(
+	ctx context.Context,
+	monitor SSLMonitor,
+) (*SSLMonitor, error) {
+	payload := createSSLMonitorPayload(monitor)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	status, res, err := c.apiCall(
+		ctx,
+		http.MethodPost,
+		withAutoAssignAlertsFlag("checks/ssl"),
+		data,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result SSLMonitor
 	if err = json.NewDecoder(strings.NewReader(res)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
 	}
@@ -856,6 +920,36 @@ func (c *client) UpdateTracerouteMonitor(
 	return &result, nil
 }
 
+func (c *client) UpdateSSLMonitor(
+	ctx context.Context,
+	ID string,
+	monitor SSLMonitor,
+) (*SSLMonitor, error) {
+	payload := createSSLMonitorPayload(monitor)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	status, res, err := c.apiCall(
+		ctx,
+		http.MethodPut,
+		withAutoAssignAlertsFlag(fmt.Sprintf("checks/ssl/%s", ID)),
+		data,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result SSLMonitor
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
 func (c *client) UpdateURLMonitor(
 	ctx context.Context,
 	ID string,
@@ -1018,6 +1112,13 @@ func (c *client) DeleteGRPCMonitor(
 }
 
 func (c *client) DeleteTracerouteMonitor(
+	ctx context.Context,
+	ID string,
+) error {
+	return c.DeleteCheck(ctx, ID)
+}
+
+func (c *client) DeleteSSLMonitor(
 	ctx context.Context,
 	ID string,
 ) error {
@@ -1192,6 +1293,32 @@ func (c *client) GetTracerouteMonitor(
 		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
 	}
 	var result TracerouteMonitor
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
+// GetSSLMonitor takes the ID of an existing SSL monitor, and returns the
+// monitor parameters, or an error.
+func (c *client) GetSSLMonitor(
+	ctx context.Context,
+	ID string,
+) (*SSLMonitor, error) {
+	status, res, err := c.apiCall(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("checks/%s", ID),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result SSLMonitor
 	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
 	if err != nil {
 		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)

--- a/checkly.go
+++ b/checkly.go
@@ -149,6 +149,8 @@ func (c *client) CreateCheck(
 		return nil, fmt.Errorf("user error: use CreateDNSMonitor to create DNS monitors")
 	case "ICMP":
 		return nil, fmt.Errorf("user error: use CreateICMPMonitor to create ICMP monitors")
+	case "GRPC":
+		return nil, fmt.Errorf("user error: use CreateGRPCMonitor to create GRPC monitors")
 	default:
 		return nil, fmt.Errorf("unknown check type: %s", check.Type)
 	}
@@ -311,6 +313,68 @@ func (c *client) CreateTCPMonitor(
 		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
 	}
 	var result TCPMonitor
+	if err = json.NewDecoder(strings.NewReader(res)).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
+type grpcMonitorPayload struct {
+	GRPCMonitor
+	Type        string `json:"checkType"`
+	DoubleCheck bool   `json:"doubleCheck"`
+	GroupID     *int64 `json:"groupId"`
+}
+
+func createGRPCMonitorPayload(monitor GRPCMonitor) grpcMonitorPayload {
+	payload := grpcMonitorPayload{
+		GRPCMonitor: monitor,
+		// Unfortunately `checkType` is required for this endpoint.
+		Type: "GRPC",
+		// Unfortunately, this will default to true if not set.
+		DoubleCheck: false,
+	}
+
+	// GroupID must be null if empty or the group will not get unset on update.
+	if monitor.GroupID != 0 {
+		payload.GroupID = &monitor.GroupID
+	}
+
+	// A nil value for a list will cause the backend to not update the value.
+	// We must send empty lists instead.
+	if monitor.Locations == nil {
+		payload.Locations = []string{}
+	}
+
+	if monitor.PrivateLocations == nil {
+		payload.PrivateLocations = &[]string{}
+	}
+
+	return payload
+}
+
+func (c *client) CreateGRPCMonitor(
+	ctx context.Context,
+	monitor GRPCMonitor,
+) (*GRPCMonitor, error) {
+	payload := createGRPCMonitorPayload(monitor)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	status, res, err := c.apiCall(
+		ctx,
+		http.MethodPost,
+		withAutoAssignAlertsFlag("checks/grpc"),
+		data,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result GRPCMonitor
 	if err = json.NewDecoder(strings.NewReader(res)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
 	}
@@ -667,6 +731,36 @@ func (c *client) UpdateTCPMonitor(
 	return &result, nil
 }
 
+func (c *client) UpdateGRPCMonitor(
+	ctx context.Context,
+	ID string,
+	monitor GRPCMonitor,
+) (*GRPCMonitor, error) {
+	payload := createGRPCMonitorPayload(monitor)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	status, res, err := c.apiCall(
+		ctx,
+		http.MethodPut,
+		withAutoAssignAlertsFlag(fmt.Sprintf("checks/grpc/%s", ID)),
+		data,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result GRPCMonitor
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
 func (c *client) UpdateURLMonitor(
 	ctx context.Context,
 	ID string,
@@ -821,6 +915,13 @@ func (c *client) DeleteTCPMonitor(
 	return c.DeleteCheck(ctx, ID)
 }
 
+func (c *client) DeleteGRPCMonitor(
+	ctx context.Context,
+	ID string,
+) error {
+	return c.DeleteCheck(ctx, ID)
+}
+
 func (c *client) DeleteURLMonitor(
 	ctx context.Context,
 	ID string,
@@ -937,6 +1038,32 @@ func (c *client) GetTCPMonitor(
 		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
 	}
 	var result TCPMonitor
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
+// GetGRPCMonitor takes the ID of an existing gRPC monitor, and returns the
+// monitor parameters, or an error.
+func (c *client) GetGRPCMonitor(
+	ctx context.Context,
+	ID string,
+) (*GRPCMonitor, error) {
+	status, res, err := c.apiCall(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("checks/%s", ID),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result GRPCMonitor
 	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
 	if err != nil {
 		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)

--- a/checkly.go
+++ b/checkly.go
@@ -151,6 +151,8 @@ func (c *client) CreateCheck(
 		return nil, fmt.Errorf("user error: use CreateICMPMonitor to create ICMP monitors")
 	case "GRPC":
 		return nil, fmt.Errorf("user error: use CreateGRPCMonitor to create GRPC monitors")
+	case "TRACEROUTE":
+		return nil, fmt.Errorf("user error: use CreateTracerouteMonitor to create TRACEROUTE monitors")
 	default:
 		return nil, fmt.Errorf("unknown check type: %s", check.Type)
 	}
@@ -375,6 +377,69 @@ func (c *client) CreateGRPCMonitor(
 		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
 	}
 	var result GRPCMonitor
+	if err = json.NewDecoder(strings.NewReader(res)).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
+type tracerouteMonitorPayload struct {
+	TracerouteMonitor
+	Type        string `json:"checkType"`
+	DoubleCheck bool   `json:"doubleCheck"`
+	GroupID     *int64 `json:"groupId"`
+}
+
+func createTracerouteMonitorPayload(monitor TracerouteMonitor) tracerouteMonitorPayload {
+	payload := tracerouteMonitorPayload{
+		TracerouteMonitor: monitor,
+		// Unfortunately `checkType` is required for this endpoint.
+		Type: "TRACEROUTE",
+		// Unfortunately, this will default to true if not set.
+		DoubleCheck: false,
+	}
+
+	// GroupID must be null if empty or the group will not get unset on update.
+	if monitor.GroupID != 0 {
+		payload.GroupID = &monitor.GroupID
+	}
+
+	// A nil value for a list will cause the backend to not update the value.
+	// We must send empty lists instead.
+	if monitor.Locations == nil {
+		payload.Locations = []string{}
+	}
+
+	// NOTE: traceroute monitors forbid private locations (the create schema
+	// marks `privateLocations` as forbidden), so — unlike the other monitor
+	// payloads — we must not emit that field at all. TracerouteMonitor has no
+	// PrivateLocations field, so nothing to set here.
+
+	return payload
+}
+
+func (c *client) CreateTracerouteMonitor(
+	ctx context.Context,
+	monitor TracerouteMonitor,
+) (*TracerouteMonitor, error) {
+	payload := createTracerouteMonitorPayload(monitor)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	status, res, err := c.apiCall(
+		ctx,
+		http.MethodPost,
+		withAutoAssignAlertsFlag("checks/traceroute"),
+		data,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusCreated {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result TracerouteMonitor
 	if err = json.NewDecoder(strings.NewReader(res)).Decode(&result); err != nil {
 		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
 	}
@@ -761,6 +826,36 @@ func (c *client) UpdateGRPCMonitor(
 	return &result, nil
 }
 
+func (c *client) UpdateTracerouteMonitor(
+	ctx context.Context,
+	ID string,
+	monitor TracerouteMonitor,
+) (*TracerouteMonitor, error) {
+	payload := createTracerouteMonitorPayload(monitor)
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	status, res, err := c.apiCall(
+		ctx,
+		http.MethodPut,
+		withAutoAssignAlertsFlag(fmt.Sprintf("checks/traceroute/%s", ID)),
+		data,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result TracerouteMonitor
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
 func (c *client) UpdateURLMonitor(
 	ctx context.Context,
 	ID string,
@@ -922,6 +1017,13 @@ func (c *client) DeleteGRPCMonitor(
 	return c.DeleteCheck(ctx, ID)
 }
 
+func (c *client) DeleteTracerouteMonitor(
+	ctx context.Context,
+	ID string,
+) error {
+	return c.DeleteCheck(ctx, ID)
+}
+
 func (c *client) DeleteURLMonitor(
 	ctx context.Context,
 	ID string,
@@ -1064,6 +1166,32 @@ func (c *client) GetGRPCMonitor(
 		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
 	}
 	var result GRPCMonitor
+	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
+	if err != nil {
+		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)
+	}
+	return &result, nil
+}
+
+// GetTracerouteMonitor takes the ID of an existing traceroute monitor, and
+// returns the monitor parameters, or an error.
+func (c *client) GetTracerouteMonitor(
+	ctx context.Context,
+	ID string,
+) (*TracerouteMonitor, error) {
+	status, res, err := c.apiCall(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("checks/%s", ID),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status %d: %q", status, res)
+	}
+	var result TracerouteMonitor
 	err = json.NewDecoder(strings.NewReader(res)).Decode(&result)
 	if err != nil {
 		return nil, fmt.Errorf("decoding error for data %s: %v", res, err)

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -2721,6 +2721,8 @@ var testSSLMonitor = checkly.SSLMonitor{
 		},
 	},
 	UseGlobalAlertSettings: false,
+	DegradedResponseTime:   3000,
+	MaxResponseTime:        10000,
 	RetryStrategy:          nil,
 	PrivateLocations:       &[]string{},
 	Request: checkly.SSLRequest{
@@ -2732,9 +2734,7 @@ var testSSLMonitor = checkly.SSLMonitor{
 			HandshakeTimeoutMs:  10000,
 			// SecurityBaseline left nil: the create body must omit
 			// `securityBaseline` so the server applies its default baseline.
-			AlertDaysBeforeExpiry:  20,
-			DegradedResponseTimeMs: 3000,
-			MaxResponseTimeMs:      10000,
+			AlertDaysBeforeExpiry: 20,
 		},
 		Assertions: []checkly.Assertion{
 			{

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -552,6 +552,117 @@ func TestGetCheckResult(t *testing.T) {
 	}
 }
 
+func TestGetTracerouteCheckResult(t *testing.T) {
+	t.Parallel()
+	resultID := "11111111-1111-1111-1111-111111111111"
+	ts := cannedResponseServer(t,
+		http.MethodGet,
+		fmt.Sprintf("/v1/check-results/%s/%s", wantCheckID, resultID),
+		validateEmptyBody,
+		http.StatusOK,
+		"GetTracerouteCheckResult.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	result, err := client.GetCheckResult(context.Background(), wantCheckID, resultID)
+	if err != nil {
+		t.Fatalf("Expected no errors, got %v", err)
+	}
+	if result.TracerouteCheckResult == nil {
+		t.Fatal("expected tracerouteCheckResult to be populated, got nil")
+	}
+	tr := result.TracerouteCheckResult
+	if tr.TotalHops == nil || *tr.TotalHops != 12 {
+		t.Errorf("expected totalHops 12, got %v", tr.TotalHops)
+	}
+	if tr.DestinationReached == nil || *tr.DestinationReached {
+		t.Errorf("expected destinationReached false, got %v", tr.DestinationReached)
+	}
+	if tr.Response == nil || tr.Response.TruncationReason != "max-hops" {
+		t.Errorf("expected response.truncationReason max-hops, got %+v", tr.Response)
+	}
+	if tr.Response == nil || len(tr.Response.Hops) != 1 {
+		t.Errorf("expected 1 hop in response, got %+v", tr.Response)
+	}
+	if result.GRPCCheckResult != nil || result.SSLCheckResult != nil {
+		t.Errorf("expected sibling typed results nil, got grpc=%v ssl=%v", result.GRPCCheckResult, result.SSLCheckResult)
+	}
+}
+
+func TestGetGRPCCheckResult(t *testing.T) {
+	t.Parallel()
+	resultID := "22222222-2222-2222-2222-222222222222"
+	ts := cannedResponseServer(t,
+		http.MethodGet,
+		fmt.Sprintf("/v1/check-results/%s/%s", wantCheckID, resultID),
+		validateEmptyBody,
+		http.StatusOK,
+		"GetGRPCCheckResult.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	result, err := client.GetCheckResult(context.Background(), wantCheckID, resultID)
+	if err != nil {
+		t.Fatalf("Expected no errors, got %v", err)
+	}
+	if result.GRPCCheckResult == nil {
+		t.Fatal("expected grpcCheckResult to be populated, got nil")
+	}
+	g := result.GRPCCheckResult
+	if g.GRPCStatusCode == nil || *g.GRPCStatusCode != 14 {
+		t.Errorf("expected grpcStatusCode 14, got %v", g.GRPCStatusCode)
+	}
+	if g.Response == nil {
+		t.Fatal("expected grpc response artifact, got nil")
+	}
+	if g.Response.GRPCStatusMessage != "connection refused" {
+		t.Errorf("expected grpcStatusMessage 'connection refused', got %q", g.Response.GRPCStatusMessage)
+	}
+	if g.Response.HealthStatusLabel != "NOT_SERVING" {
+		t.Errorf("expected healthStatusLabel NOT_SERVING, got %q", g.Response.HealthStatusLabel)
+	}
+	if len(g.Response.DiscoveredMethods) != 1 || len(g.Response.Metadata) != 1 {
+		t.Errorf("expected 1 discovered method and 1 metadata entry, got %+v", g.Response)
+	}
+}
+
+func TestGetSSLCheckResult(t *testing.T) {
+	t.Parallel()
+	resultID := "33333333-3333-3333-3333-333333333333"
+	ts := cannedResponseServer(t,
+		http.MethodGet,
+		fmt.Sprintf("/v1/check-results/%s/%s", wantCheckID, resultID),
+		validateEmptyBody,
+		http.StatusOK,
+		"GetSSLCheckResult.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	result, err := client.GetCheckResult(context.Background(), wantCheckID, resultID)
+	if err != nil {
+		t.Fatalf("Expected no errors, got %v", err)
+	}
+	if result.SSLCheckResult == nil {
+		t.Fatal("expected sslCheckResult to be populated, got nil")
+	}
+	s := result.SSLCheckResult
+	if s.TLSVersion != "TLS 1.3" || s.CipherSuite != "TLS_AES_256_GCM_SHA384" {
+		t.Errorf("expected TLS 1.3 / AES_256, got %q / %q", s.TLSVersion, s.CipherSuite)
+	}
+	if s.DaysUntilExpiry == nil || *s.DaysUntilExpiry != -3 {
+		t.Errorf("expected daysUntilExpiry -3, got %v", s.DaysUntilExpiry)
+	}
+	if s.ChainTrusted == nil || *s.ChainTrusted {
+		t.Errorf("expected chainTrusted false, got %v", s.ChainTrusted)
+	}
+	if s.FailureCategory != "expired" {
+		t.Errorf("expected failureCategory expired, got %q", s.FailureCategory)
+	}
+	if s.Response == nil || s.Response.Certificate["subjectCN"] != "expired.example.com" {
+		t.Errorf("expected response.certificate.subjectCN, got %+v", s.Response)
+	}
+}
+
 func TestGetCheckResults(t *testing.T) {
 	t.Parallel()
 	ts := cannedResponseServer(t,

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -2738,10 +2738,28 @@ var testSSLMonitor = checkly.SSLMonitor{
 		},
 		Assertions: []checkly.Assertion{
 			{
-				Source:     "CERT_DAYS_REMAINING",
-				Target:     "30",
-				Property:   "",
-				Comparison: "LESS_THAN",
+				Source:     checkly.Certificate,
+				Property:   "daysUntilExpiry",
+				Comparison: checkly.GreaterThan,
+				Target:     "14",
+			},
+			{
+				Source:     checkly.Connection,
+				Property:   "tlsVersion",
+				Comparison: checkly.Equals,
+				Target:     "TLSv1.3",
+			},
+			{
+				Source:     checkly.JSONResponse,
+				Property:   "$.certificate.keySizeBits",
+				Comparison: checkly.GreaterThan,
+				Target:     "2048",
+			},
+			{
+				Source:     checkly.TextResponse,
+				Property:   "Issuer:.*Let's Encrypt",
+				Comparison: checkly.Contains,
+				Target:     "true",
 			},
 		},
 	},

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -2283,3 +2283,550 @@ func TestGetICMPMonitor(t *testing.T) {
 		t.Error(cmp.Diff(testICMPMonitor, *response, ignoreICMPMonitorFields))
 	}
 }
+
+// --- gRPC monitor -----------------------------------------------------------
+
+func validateGRPCMonitor(t *testing.T, body []byte) {
+	var payload checkly.GRPCMonitor
+	err := json.Unmarshal(body, &payload)
+	if err != nil {
+		t.Fatalf("decoding error for data %q: %v", body, err)
+	}
+	if !cmp.Equal(testGRPCMonitor, payload, ignoreGRPCMonitorFields) {
+		t.Error(cmp.Diff(testGRPCMonitor, payload, ignoreGRPCMonitorFields))
+	}
+}
+
+var testGRPCMonitor = checkly.GRPCMonitor{
+	ID:              "a1b2c3d4-1111-2222-3333-444455556666",
+	Name:            "gRPC Monitor #1",
+	Frequency:       10,
+	FrequencyOffset: 80,
+	Activated:       false,
+	Muted:           false,
+	Locations:       []string{"us-east-1"},
+	Tags: []string{
+		"tag-1",
+	},
+	AlertSettings: &checkly.AlertSettings{
+		EscalationType: checkly.RunBased,
+		RunBasedEscalation: checkly.RunBasedEscalation{
+			FailedRunThreshold: 1,
+		},
+		Reminders: checkly.Reminders{
+			Interval: 5,
+		},
+		ParallelRunFailureThreshold: checkly.ParallelRunFailureThreshold{
+			Enabled:    false,
+			Percentage: 10,
+		},
+	},
+	UseGlobalAlertSettings: false,
+	DegradedResponseTime:   3000,
+	MaxResponseTime:        5000,
+	RetryStrategy:          nil,
+	PrivateLocations:       &[]string{},
+	Request: checkly.GRPCRequest{
+		URL: "grpc.example.com",
+		// interface{} port decodes from JSON as a float64, so the expected
+		// value must use the same concrete type for cmp to match.
+		Port:     float64(443),
+		IPFamily: "IPv4",
+		SkipSSL:  false,
+		Timeout:  30,
+		GRPCConfig: checkly.GRPCConfig{
+			Mode:   "BEHAVIOR",
+			TLS:    true,
+			Method: "/grpc.health.v1.Health/Check",
+		},
+		Assertions: []checkly.Assertion{
+			{
+				Source:     "GRPC_STATUS",
+				Target:     "0",
+				Property:   "",
+				Comparison: "EQUALS",
+			},
+		},
+	},
+}
+
+var ignoreGRPCMonitorFields = cmpopts.IgnoreFields(
+	checkly.GRPCMonitor{},
+	"ID",
+	"AlertChannelSubscriptions",
+	"CreatedAt",
+	"UpdatedAt",
+)
+
+func TestCreateGRPCMonitor(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodPost,
+		"/v1/checks/grpc?autoAssignAlerts=false",
+		validateGRPCMonitor,
+		http.StatusCreated,
+		"CreateGRPCMonitor.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	response, err := client.CreateGRPCMonitor(context.Background(), testGRPCMonitor)
+	if err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(testGRPCMonitor, *response, ignoreGRPCMonitorFields) {
+		t.Error(cmp.Diff(testGRPCMonitor, *response, ignoreGRPCMonitorFields))
+	}
+}
+
+func TestDeleteGRPCMonitor(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodDelete,
+		fmt.Sprintf("/v1/checks/%s", testGRPCMonitor.ID),
+		validateEmptyBody,
+		http.StatusNoContent,
+		"Empty.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	err := client.DeleteGRPCMonitor(context.Background(), testGRPCMonitor.ID)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpdateGRPCMonitor(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodPut,
+		fmt.Sprintf("/v1/checks/grpc/%s?autoAssignAlerts=false", testGRPCMonitor.ID),
+		validateGRPCMonitor,
+		http.StatusOK,
+		"UpdateGRPCMonitor.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	_, err := client.UpdateGRPCMonitor(context.Background(), testGRPCMonitor.ID, testGRPCMonitor)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGetGRPCMonitor(t *testing.T) {
+	ts := cannedResponseServer(t,
+		http.MethodGet,
+		fmt.Sprintf("/v1/checks/%s", testGRPCMonitor.ID),
+		validateEmptyBody,
+		http.StatusOK,
+		"GetGRPCMonitor.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	response, err := client.GetGRPCMonitor(context.Background(), testGRPCMonitor.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cmp.Equal(testGRPCMonitor, *response, ignoreGRPCMonitorFields) {
+		t.Error(cmp.Diff(testGRPCMonitor, *response, ignoreGRPCMonitorFields))
+	}
+}
+
+// --- traceroute monitor -----------------------------------------------------
+
+func validateTracerouteMonitor(t *testing.T, body []byte) {
+	var payload checkly.TracerouteMonitor
+	err := json.Unmarshal(body, &payload)
+	if err != nil {
+		t.Fatalf("decoding error for data %q: %v", body, err)
+	}
+	if !cmp.Equal(testTracerouteMonitor, payload, ignoreTracerouteMonitorFields) {
+		t.Error(cmp.Diff(testTracerouteMonitor, payload, ignoreTracerouteMonitorFields))
+	}
+}
+
+var testTracerouteMonitor = checkly.TracerouteMonitor{
+	ID:              "b2c3d4e5-1111-2222-3333-444455556666",
+	Name:            "Traceroute Monitor #1",
+	Frequency:       10,
+	FrequencyOffset: 80,
+	Activated:       false,
+	Muted:           false,
+	Locations:       []string{"us-east-1"},
+	Tags: []string{
+		"tag-1",
+	},
+	AlertSettings: &checkly.AlertSettings{
+		EscalationType: checkly.RunBased,
+		RunBasedEscalation: checkly.RunBasedEscalation{
+			FailedRunThreshold: 1,
+		},
+		Reminders: checkly.Reminders{
+			Interval: 5,
+		},
+		ParallelRunFailureThreshold: checkly.ParallelRunFailureThreshold{
+			Enabled:    false,
+			Percentage: 10,
+		},
+	},
+	UseGlobalAlertSettings: false,
+	DegradedResponseTime:   3000,
+	MaxResponseTime:        5000,
+	RetryStrategy:          nil,
+	Request: checkly.TracerouteRequest{
+		URL:      "traceroute.example.com",
+		Protocol: "ICMP",
+		// No Port: the ICMP protocol strips it from the wire (see MarshalJSON).
+		IPFamily:       "IPv4",
+		MaxHops:        30,
+		MaxUnknownHops: 5,
+		Timeout:        30,
+		Assertions: []checkly.Assertion{
+			{
+				Source:     "LATENCY",
+				Target:     "200",
+				Property:   "avg",
+				Comparison: "LESS_THAN",
+			},
+		},
+	},
+}
+
+var ignoreTracerouteMonitorFields = cmpopts.IgnoreFields(
+	checkly.TracerouteMonitor{},
+	"ID",
+	"AlertChannelSubscriptions",
+	"CreatedAt",
+	"UpdatedAt",
+)
+
+func TestCreateTracerouteMonitor(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodPost,
+		"/v1/checks/traceroute?autoAssignAlerts=false",
+		validateTracerouteMonitor,
+		http.StatusCreated,
+		"CreateTracerouteMonitor.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	response, err := client.CreateTracerouteMonitor(context.Background(), testTracerouteMonitor)
+	if err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(testTracerouteMonitor, *response, ignoreTracerouteMonitorFields) {
+		t.Error(cmp.Diff(testTracerouteMonitor, *response, ignoreTracerouteMonitorFields))
+	}
+}
+
+func TestDeleteTracerouteMonitor(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodDelete,
+		fmt.Sprintf("/v1/checks/%s", testTracerouteMonitor.ID),
+		validateEmptyBody,
+		http.StatusNoContent,
+		"Empty.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	err := client.DeleteTracerouteMonitor(context.Background(), testTracerouteMonitor.ID)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpdateTracerouteMonitor(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodPut,
+		fmt.Sprintf("/v1/checks/traceroute/%s?autoAssignAlerts=false", testTracerouteMonitor.ID),
+		validateTracerouteMonitor,
+		http.StatusOK,
+		"UpdateTracerouteMonitor.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	_, err := client.UpdateTracerouteMonitor(context.Background(), testTracerouteMonitor.ID, testTracerouteMonitor)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGetTracerouteMonitor(t *testing.T) {
+	ts := cannedResponseServer(t,
+		http.MethodGet,
+		fmt.Sprintf("/v1/checks/%s", testTracerouteMonitor.ID),
+		validateEmptyBody,
+		http.StatusOK,
+		"GetTracerouteMonitor.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	response, err := client.GetTracerouteMonitor(context.Background(), testTracerouteMonitor.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cmp.Equal(testTracerouteMonitor, *response, ignoreTracerouteMonitorFields) {
+		t.Error(cmp.Diff(testTracerouteMonitor, *response, ignoreTracerouteMonitorFields))
+	}
+}
+
+// --- SSL monitor ------------------------------------------------------------
+
+func validateSSLMonitor(t *testing.T, body []byte) {
+	var payload checkly.SSLMonitor
+	err := json.Unmarshal(body, &payload)
+	if err != nil {
+		t.Fatalf("decoding error for data %q: %v", body, err)
+	}
+	if !cmp.Equal(testSSLMonitor, payload, ignoreSSLMonitorFields) {
+		t.Error(cmp.Diff(testSSLMonitor, payload, ignoreSSLMonitorFields))
+	}
+}
+
+var testSSLMonitor = checkly.SSLMonitor{
+	ID:              "c3d4e5f6-1111-2222-3333-444455556666",
+	Name:            "SSL Monitor #1",
+	Frequency:       10,
+	FrequencyOffset: 80,
+	Activated:       false,
+	Muted:           false,
+	Locations:       []string{"us-east-1"},
+	Tags: []string{
+		"tag-1",
+	},
+	AlertSettings: &checkly.AlertSettings{
+		EscalationType: checkly.RunBased,
+		RunBasedEscalation: checkly.RunBasedEscalation{
+			FailedRunThreshold: 1,
+		},
+		Reminders: checkly.Reminders{
+			Interval: 5,
+		},
+		ParallelRunFailureThreshold: checkly.ParallelRunFailureThreshold{
+			Enabled:    false,
+			Percentage: 10,
+		},
+	},
+	UseGlobalAlertSettings: false,
+	RetryStrategy:          nil,
+	PrivateLocations:       &[]string{},
+	Request: checkly.SSLRequest{
+		SSLConfig: checkly.SSLConfig{
+			Hostname:            "example.com",
+			Port:                443,
+			IPFamily:            "IPv4",
+			SkipChainValidation: false,
+			HandshakeTimeoutMs:  10000,
+			// SecurityBaseline left nil: the create body must omit
+			// `securityBaseline` so the server applies its default baseline.
+			AlertDaysBeforeExpiry:  20,
+			DegradedResponseTimeMs: 3000,
+			MaxResponseTimeMs:      10000,
+		},
+		Assertions: []checkly.Assertion{
+			{
+				Source:     "CERT_DAYS_REMAINING",
+				Target:     "30",
+				Property:   "",
+				Comparison: "LESS_THAN",
+			},
+		},
+	},
+}
+
+var ignoreSSLMonitorFields = cmpopts.IgnoreFields(
+	checkly.SSLMonitor{},
+	"ID",
+	"AlertChannelSubscriptions",
+	"CreatedAt",
+	"UpdatedAt",
+)
+
+func TestCreateSSLMonitor(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodPost,
+		"/v1/checks/ssl?autoAssignAlerts=false",
+		validateSSLMonitor,
+		http.StatusCreated,
+		"CreateSSLMonitor.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	response, err := client.CreateSSLMonitor(context.Background(), testSSLMonitor)
+	if err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(testSSLMonitor, *response, ignoreSSLMonitorFields) {
+		t.Error(cmp.Diff(testSSLMonitor, *response, ignoreSSLMonitorFields))
+	}
+}
+
+func TestDeleteSSLMonitor(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodDelete,
+		fmt.Sprintf("/v1/checks/%s", testSSLMonitor.ID),
+		validateEmptyBody,
+		http.StatusNoContent,
+		"Empty.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	err := client.DeleteSSLMonitor(context.Background(), testSSLMonitor.ID)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestUpdateSSLMonitor(t *testing.T) {
+	t.Parallel()
+	ts := cannedResponseServer(t,
+		http.MethodPut,
+		fmt.Sprintf("/v1/checks/ssl/%s?autoAssignAlerts=false", testSSLMonitor.ID),
+		validateSSLMonitor,
+		http.StatusOK,
+		"UpdateSSLMonitor.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	_, err := client.UpdateSSLMonitor(context.Background(), testSSLMonitor.ID, testSSLMonitor)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestGetSSLMonitor(t *testing.T) {
+	ts := cannedResponseServer(t,
+		http.MethodGet,
+		fmt.Sprintf("/v1/checks/%s", testSSLMonitor.ID),
+		validateEmptyBody,
+		http.StatusOK,
+		"GetSSLMonitor.json",
+	)
+	defer ts.Close()
+	client := checkly.NewClient(ts.URL, "dummy-key", ts.Client(), nil)
+	response, err := client.GetSSLMonitor(context.Background(), testSSLMonitor.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cmp.Equal(testSSLMonitor, *response, ignoreSSLMonitorFields) {
+		t.Error(cmp.Diff(testSSLMonitor, *response, ignoreSSLMonitorFields))
+	}
+}
+
+// --- forbidden-field (anti-pattern) tests -----------------------------------
+
+// TestTracerouteRequestStripsPortForICMP asserts the wire body omits `port`
+// for an ICMP probe (mirroring the public API's Joi `.strip()`), while keeping
+// it for non-ICMP protocols.
+func TestTracerouteRequestStripsPortForICMP(t *testing.T) {
+	t.Parallel()
+	icmp, err := json.Marshal(checkly.TracerouteRequest{
+		URL:      "traceroute.example.com",
+		Protocol: "ICMP",
+		Port:     33434,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var icmpBody map[string]interface{}
+	if err := json.Unmarshal(icmp, &icmpBody); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := icmpBody["port"]; ok {
+		t.Errorf("ICMP traceroute body must omit `port`, got: %s", icmp)
+	}
+
+	tcp, err := json.Marshal(checkly.TracerouteRequest{
+		URL:      "traceroute.example.com",
+		Protocol: "TCP",
+		Port:     33434,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tcpBody map[string]interface{}
+	if err := json.Unmarshal(tcp, &tcpBody); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := tcpBody["port"]; !ok {
+		t.Errorf("non-ICMP traceroute body must keep `port`, got: %s", tcp)
+	}
+}
+
+// TestGRPCConfigModeForbiddenFields asserts the BEHAVIOR-only keys are dropped
+// from a HEALTH-mode config and the HEALTH-only `service` key is dropped from a
+// BEHAVIOR-mode config — the mode-exclusive fields must never reach the wire.
+func TestGRPCConfigModeForbiddenFields(t *testing.T) {
+	t.Parallel()
+	health, err := json.Marshal(checkly.GRPCConfig{
+		Mode:    "HEALTH",
+		TLS:     true,
+		Service: "grpc.health.v1.Health",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var healthBody map[string]interface{}
+	if err := json.Unmarshal(health, &healthBody); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"method", "serviceDefinition", "protoContent", "message"} {
+		if _, ok := healthBody[k]; ok {
+			t.Errorf("HEALTH-mode gRPC config must omit %q, got: %s", k, health)
+		}
+	}
+	if _, ok := healthBody["service"]; !ok {
+		t.Errorf("HEALTH-mode gRPC config must keep `service`, got: %s", health)
+	}
+
+	behavior, err := json.Marshal(checkly.GRPCConfig{
+		Mode:              "BEHAVIOR",
+		TLS:               true,
+		Method:            "/grpc.health.v1.Health/Check",
+		ServiceDefinition: "syntax = \"proto3\";",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var behaviorBody map[string]interface{}
+	if err := json.Unmarshal(behavior, &behaviorBody); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := behaviorBody["service"]; ok {
+		t.Errorf("BEHAVIOR-mode gRPC config must omit `service`, got: %s", behavior)
+	}
+	for _, k := range []string{"method", "serviceDefinition"} {
+		if _, ok := behaviorBody[k]; !ok {
+			t.Errorf("BEHAVIOR-mode gRPC config must keep %q, got: %s", k, behavior)
+		}
+	}
+}
+
+// TestSSLConfigOmitsSecurityBaselineWhenNil asserts a create body with a nil
+// SecurityBaseline omits the `securityBaseline` key so the server applies its
+// default baseline rather than receiving an empty override.
+func TestSSLConfigOmitsSecurityBaselineWhenNil(t *testing.T) {
+	t.Parallel()
+	body, err := json.Marshal(testSSLMonitor.Request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reqBody map[string]interface{}
+	if err := json.Unmarshal(body, &reqBody); err != nil {
+		t.Fatal(err)
+	}
+	sslConfig, ok := reqBody["sslConfig"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected `sslConfig` object in request body, got: %s", body)
+	}
+	if _, ok := sslConfig["securityBaseline"]; ok {
+		t.Errorf("SSL config must omit `securityBaseline` when nil, got: %s", body)
+	}
+	if _, ok := reqBody["sslClientCertificateId"]; ok {
+		t.Errorf("SSL request must omit `sslClientCertificateId` when nil, got: %s", body)
+	}
+}

--- a/fixtures/CreateGRPCMonitor.json
+++ b/fixtures/CreateGRPCMonitor.json
@@ -1,0 +1,64 @@
+{
+  "activated": false,
+  "alertChannelSubscriptions": [],
+  "alertSettings": {
+    "escalationType": "RUN_BASED",
+    "parallelRunFailureThreshold": {
+      "enabled": false,
+      "percentage": 10
+    },
+    "reminders": {
+      "amount": 0,
+      "interval": 5
+    },
+    "runBasedEscalation": {
+      "failedRunThreshold": 1
+    }
+  },
+  "checkType": "GRPC",
+  "created_at": "2025-10-30T05:34:01.240Z",
+  "degradedResponseTime": 3000,
+  "doubleCheck": false,
+  "frequency": 10,
+  "frequencyOffset": 80,
+  "groupId": null,
+  "groupOrder": null,
+  "id": "a1b2c3d4-1111-2222-3333-444455556666",
+  "locations": [
+    "us-east-1"
+  ],
+  "maxResponseTime": 5000,
+  "muted": false,
+  "name": "gRPC Monitor #1",
+  "privateLocations": [],
+  "request": {
+    "assertions": [
+      {
+        "comparison": "EQUALS",
+        "property": "",
+        "source": "GRPC_STATUS",
+        "target": "0"
+      }
+    ],
+    "grpcConfig": {
+      "method": "/grpc.health.v1.Health/Check",
+      "mode": "BEHAVIOR",
+      "storeResponseBody": false,
+      "tls": true
+    },
+    "ipFamily": "IPv4",
+    "port": 443,
+    "skipSSL": false,
+    "timeout": 30,
+    "url": "grpc.example.com"
+  },
+  "retryStrategy": null,
+  "runParallel": false,
+  "runtimeId": null,
+  "shouldFail": false,
+  "tags": [
+    "tag-1"
+  ],
+  "triggerIncident": null,
+  "useGlobalAlertSettings": false
+}

--- a/fixtures/CreateSSLMonitor.json
+++ b/fixtures/CreateSSLMonitor.json
@@ -1,0 +1,61 @@
+{
+  "activated": false,
+  "alertChannelSubscriptions": [],
+  "alertSettings": {
+    "escalationType": "RUN_BASED",
+    "parallelRunFailureThreshold": {
+      "enabled": false,
+      "percentage": 10
+    },
+    "reminders": {
+      "amount": 0,
+      "interval": 5
+    },
+    "runBasedEscalation": {
+      "failedRunThreshold": 1
+    }
+  },
+  "checkType": "SSL",
+  "created_at": "2025-10-30T05:34:01.240Z",
+  "doubleCheck": false,
+  "frequency": 10,
+  "frequencyOffset": 80,
+  "groupId": null,
+  "groupOrder": null,
+  "id": "c3d4e5f6-1111-2222-3333-444455556666",
+  "locations": [
+    "us-east-1"
+  ],
+  "muted": false,
+  "name": "SSL Monitor #1",
+  "privateLocations": [],
+  "request": {
+    "assertions": [
+      {
+        "comparison": "LESS_THAN",
+        "property": "",
+        "source": "CERT_DAYS_REMAINING",
+        "target": "30"
+      }
+    ],
+    "sslConfig": {
+      "alertDaysBeforeExpiry": 20,
+      "degradedResponseTimeMs": 3000,
+      "handshakeTimeoutMs": 10000,
+      "hostname": "example.com",
+      "ipFamily": "IPv4",
+      "maxResponseTimeMs": 10000,
+      "port": 443,
+      "skipChainValidation": false
+    }
+  },
+  "retryStrategy": null,
+  "runParallel": false,
+  "runtimeId": null,
+  "shouldFail": false,
+  "tags": [
+    "tag-1"
+  ],
+  "triggerIncident": null,
+  "useGlobalAlertSettings": false
+}

--- a/fixtures/CreateSSLMonitor.json
+++ b/fixtures/CreateSSLMonitor.json
@@ -34,10 +34,28 @@
   "request": {
     "assertions": [
       {
-        "comparison": "LESS_THAN",
-        "property": "",
-        "source": "CERT_DAYS_REMAINING",
-        "target": "30"
+        "comparison": "GREATER_THAN",
+        "property": "daysUntilExpiry",
+        "source": "CERTIFICATE",
+        "target": "14"
+      },
+      {
+        "comparison": "EQUALS",
+        "property": "tlsVersion",
+        "source": "CONNECTION",
+        "target": "TLSv1.3"
+      },
+      {
+        "comparison": "GREATER_THAN",
+        "property": "$.certificate.keySizeBits",
+        "source": "JSON_RESPONSE",
+        "target": "2048"
+      },
+      {
+        "comparison": "CONTAINS",
+        "property": "Issuer:.*Let's Encrypt",
+        "source": "TEXT_RESPONSE",
+        "target": "true"
       }
     ],
     "sslConfig": {

--- a/fixtures/CreateSSLMonitor.json
+++ b/fixtures/CreateSSLMonitor.json
@@ -17,6 +17,7 @@
   },
   "checkType": "SSL",
   "created_at": "2025-10-30T05:34:01.240Z",
+  "degradedResponseTime": 3000,
   "doubleCheck": false,
   "frequency": 10,
   "frequencyOffset": 80,
@@ -26,6 +27,7 @@
   "locations": [
     "us-east-1"
   ],
+  "maxResponseTime": 10000,
   "muted": false,
   "name": "SSL Monitor #1",
   "privateLocations": [],
@@ -40,11 +42,9 @@
     ],
     "sslConfig": {
       "alertDaysBeforeExpiry": 20,
-      "degradedResponseTimeMs": 3000,
       "handshakeTimeoutMs": 10000,
       "hostname": "example.com",
       "ipFamily": "IPv4",
-      "maxResponseTimeMs": 10000,
       "port": 443,
       "skipChainValidation": false
     }

--- a/fixtures/CreateTracerouteMonitor.json
+++ b/fixtures/CreateTracerouteMonitor.json
@@ -1,0 +1,58 @@
+{
+  "activated": false,
+  "alertChannelSubscriptions": [],
+  "alertSettings": {
+    "escalationType": "RUN_BASED",
+    "parallelRunFailureThreshold": {
+      "enabled": false,
+      "percentage": 10
+    },
+    "reminders": {
+      "amount": 0,
+      "interval": 5
+    },
+    "runBasedEscalation": {
+      "failedRunThreshold": 1
+    }
+  },
+  "checkType": "TRACEROUTE",
+  "created_at": "2025-10-30T05:34:01.240Z",
+  "degradedResponseTime": 3000,
+  "doubleCheck": false,
+  "frequency": 10,
+  "frequencyOffset": 80,
+  "groupId": null,
+  "groupOrder": null,
+  "id": "b2c3d4e5-1111-2222-3333-444455556666",
+  "locations": [
+    "us-east-1"
+  ],
+  "maxResponseTime": 5000,
+  "muted": false,
+  "name": "Traceroute Monitor #1",
+  "request": {
+    "assertions": [
+      {
+        "comparison": "LESS_THAN",
+        "property": "avg",
+        "source": "LATENCY",
+        "target": "200"
+      }
+    ],
+    "ipFamily": "IPv4",
+    "maxHops": 30,
+    "maxUnknownHops": 5,
+    "protocol": "ICMP",
+    "timeout": 30,
+    "url": "traceroute.example.com"
+  },
+  "retryStrategy": null,
+  "runParallel": false,
+  "runtimeId": null,
+  "shouldFail": false,
+  "tags": [
+    "tag-1"
+  ],
+  "triggerIncident": null,
+  "useGlobalAlertSettings": false
+}

--- a/fixtures/GetGRPCCheckResult.json
+++ b/fixtures/GetGRPCCheckResult.json
@@ -1,0 +1,44 @@
+{
+    "id": "22222222-2222-2222-2222-222222222222",
+    "hasErrors": true,
+    "hasFailures": true,
+    "runLocation": "eu-central-1",
+    "startedAt": "2020-09-02T11:19:06.283Z",
+    "stoppedAt": "2020-09-02T11:19:06.413Z",
+    "responseTime": 90,
+    "grpcCheckResult": {
+        "grpcStatusCode": 14,
+        "healthStatus": 2,
+        "timingPhases": { "dns": 1.2, "connect": 16.8, "total": 90.0 },
+        "requestError": "connection refused",
+        "request": { "url": "grpc.example.com", "port": 443 },
+        "assertions": [
+            { "source": "GRPC_STATUS", "comparison": "EQUALS", "target": 0, "actual": 14 }
+        ],
+        "response": {
+            "grpcMode": "HEALTH",
+            "host": "grpc.example.com",
+            "resolvedIp": "10.0.0.4",
+            "port": 443,
+            "grpcMethod": "grpc.health.v1.Health/Check",
+            "responseMessage": "",
+            "grpcStatusCode": 14,
+            "grpcStatusMessage": "connection refused",
+            "healthStatus": 2,
+            "healthStatusLabel": "NOT_SERVING",
+            "metadata": [
+                { "key": "content-type", "value": "application/grpc" }
+            ],
+            "discoveredMethods": ["grpc.health.v1.Health/Check"],
+            "requestError": "connection refused",
+            "timingPhases": { "total": 90.0 }
+        }
+    },
+    "checkId": "73d29e72-6540-4bb5-967e-e07fa2c9465e",
+    "created_at": "2020-09-02T11:19:06.681Z",
+    "name": "gRPC monitor 1",
+    "checkRunId": 1599045546011,
+    "attempts": 1,
+    "isDegraded": false,
+    "overMaxResponseTime": false
+}

--- a/fixtures/GetGRPCMonitor.json
+++ b/fixtures/GetGRPCMonitor.json
@@ -1,0 +1,64 @@
+{
+  "activated": false,
+  "alertChannelSubscriptions": [],
+  "alertSettings": {
+    "escalationType": "RUN_BASED",
+    "parallelRunFailureThreshold": {
+      "enabled": false,
+      "percentage": 10
+    },
+    "reminders": {
+      "amount": 0,
+      "interval": 5
+    },
+    "runBasedEscalation": {
+      "failedRunThreshold": 1
+    }
+  },
+  "checkType": "GRPC",
+  "created_at": "2025-10-30T05:34:01.240Z",
+  "degradedResponseTime": 3000,
+  "doubleCheck": false,
+  "frequency": 10,
+  "frequencyOffset": 80,
+  "groupId": null,
+  "groupOrder": null,
+  "id": "a1b2c3d4-1111-2222-3333-444455556666",
+  "locations": [
+    "us-east-1"
+  ],
+  "maxResponseTime": 5000,
+  "muted": false,
+  "name": "gRPC Monitor #1",
+  "privateLocations": [],
+  "request": {
+    "assertions": [
+      {
+        "comparison": "EQUALS",
+        "property": "",
+        "source": "GRPC_STATUS",
+        "target": "0"
+      }
+    ],
+    "grpcConfig": {
+      "method": "/grpc.health.v1.Health/Check",
+      "mode": "BEHAVIOR",
+      "storeResponseBody": false,
+      "tls": true
+    },
+    "ipFamily": "IPv4",
+    "port": 443,
+    "skipSSL": false,
+    "timeout": 30,
+    "url": "grpc.example.com"
+  },
+  "retryStrategy": null,
+  "runParallel": false,
+  "runtimeId": null,
+  "shouldFail": false,
+  "tags": [
+    "tag-1"
+  ],
+  "triggerIncident": null,
+  "useGlobalAlertSettings": false
+}

--- a/fixtures/GetSSLCheckResult.json
+++ b/fixtures/GetSSLCheckResult.json
@@ -1,0 +1,47 @@
+{
+    "id": "33333333-3333-3333-3333-333333333333",
+    "hasErrors": false,
+    "hasFailures": true,
+    "runLocation": "eu-central-1",
+    "startedAt": "2020-09-02T11:19:06.283Z",
+    "stoppedAt": "2020-09-02T11:19:06.413Z",
+    "responseTime": 60,
+    "sslCheckResult": {
+        "tlsVersion": "TLS 1.3",
+        "cipherSuite": "TLS_AES_256_GCM_SHA384",
+        "daysUntilExpiry": -3,
+        "handshakeTimeMs": 48.2,
+        "chainTrusted": false,
+        "hostnameVerified": false,
+        "baselineVerdict": "FAIL",
+        "baselineGrade": "C",
+        "failureCategory": "expired",
+        "requestError": null,
+        "request": { "hostname": "expired.example.com", "port": 443 },
+        "assertions": [
+            { "source": "DAYS_UNTIL_EXPIRY", "comparison": "GREATER_THAN", "target": 7, "actual": -3 }
+        ],
+        "response": {
+            "resolvedIp": "104.18.7.36",
+            "protocol": "TLS 1.3",
+            "cipherSuite": "TLS_AES_256_GCM_SHA384",
+            "handshakeTimeMs": 48.2,
+            "hostnameVerified": false,
+            "chainTrusted": false,
+            "daysUntilExpiry": -3,
+            "ocspStapled": false,
+            "securityBaseline": { "verdict": "FAIL", "grade": "C" },
+            "certificate": { "issuer": "Example CA", "subjectCN": "expired.example.com" },
+            "chain": [
+                { "subjectCN": "Example CA" }
+            ]
+        }
+    },
+    "checkId": "73d29e72-6540-4bb5-967e-e07fa2c9465e",
+    "created_at": "2020-09-02T11:19:06.681Z",
+    "name": "SSL monitor 1",
+    "checkRunId": 1599045546012,
+    "attempts": 1,
+    "isDegraded": false,
+    "overMaxResponseTime": false
+}

--- a/fixtures/GetSSLMonitor.json
+++ b/fixtures/GetSSLMonitor.json
@@ -1,0 +1,61 @@
+{
+  "activated": false,
+  "alertChannelSubscriptions": [],
+  "alertSettings": {
+    "escalationType": "RUN_BASED",
+    "parallelRunFailureThreshold": {
+      "enabled": false,
+      "percentage": 10
+    },
+    "reminders": {
+      "amount": 0,
+      "interval": 5
+    },
+    "runBasedEscalation": {
+      "failedRunThreshold": 1
+    }
+  },
+  "checkType": "SSL",
+  "created_at": "2025-10-30T05:34:01.240Z",
+  "doubleCheck": false,
+  "frequency": 10,
+  "frequencyOffset": 80,
+  "groupId": null,
+  "groupOrder": null,
+  "id": "c3d4e5f6-1111-2222-3333-444455556666",
+  "locations": [
+    "us-east-1"
+  ],
+  "muted": false,
+  "name": "SSL Monitor #1",
+  "privateLocations": [],
+  "request": {
+    "assertions": [
+      {
+        "comparison": "LESS_THAN",
+        "property": "",
+        "source": "CERT_DAYS_REMAINING",
+        "target": "30"
+      }
+    ],
+    "sslConfig": {
+      "alertDaysBeforeExpiry": 20,
+      "degradedResponseTimeMs": 3000,
+      "handshakeTimeoutMs": 10000,
+      "hostname": "example.com",
+      "ipFamily": "IPv4",
+      "maxResponseTimeMs": 10000,
+      "port": 443,
+      "skipChainValidation": false
+    }
+  },
+  "retryStrategy": null,
+  "runParallel": false,
+  "runtimeId": null,
+  "shouldFail": false,
+  "tags": [
+    "tag-1"
+  ],
+  "triggerIncident": null,
+  "useGlobalAlertSettings": false
+}

--- a/fixtures/GetSSLMonitor.json
+++ b/fixtures/GetSSLMonitor.json
@@ -34,10 +34,28 @@
   "request": {
     "assertions": [
       {
-        "comparison": "LESS_THAN",
-        "property": "",
-        "source": "CERT_DAYS_REMAINING",
-        "target": "30"
+        "comparison": "GREATER_THAN",
+        "property": "daysUntilExpiry",
+        "source": "CERTIFICATE",
+        "target": "14"
+      },
+      {
+        "comparison": "EQUALS",
+        "property": "tlsVersion",
+        "source": "CONNECTION",
+        "target": "TLSv1.3"
+      },
+      {
+        "comparison": "GREATER_THAN",
+        "property": "$.certificate.keySizeBits",
+        "source": "JSON_RESPONSE",
+        "target": "2048"
+      },
+      {
+        "comparison": "CONTAINS",
+        "property": "Issuer:.*Let's Encrypt",
+        "source": "TEXT_RESPONSE",
+        "target": "true"
       }
     ],
     "sslConfig": {

--- a/fixtures/GetSSLMonitor.json
+++ b/fixtures/GetSSLMonitor.json
@@ -17,6 +17,7 @@
   },
   "checkType": "SSL",
   "created_at": "2025-10-30T05:34:01.240Z",
+  "degradedResponseTime": 3000,
   "doubleCheck": false,
   "frequency": 10,
   "frequencyOffset": 80,
@@ -26,6 +27,7 @@
   "locations": [
     "us-east-1"
   ],
+  "maxResponseTime": 10000,
   "muted": false,
   "name": "SSL Monitor #1",
   "privateLocations": [],
@@ -40,11 +42,9 @@
     ],
     "sslConfig": {
       "alertDaysBeforeExpiry": 20,
-      "degradedResponseTimeMs": 3000,
       "handshakeTimeoutMs": 10000,
       "hostname": "example.com",
       "ipFamily": "IPv4",
-      "maxResponseTimeMs": 10000,
       "port": 443,
       "skipChainValidation": false
     }

--- a/fixtures/GetTracerouteCheckResult.json
+++ b/fixtures/GetTracerouteCheckResult.json
@@ -1,0 +1,40 @@
+{
+    "id": "11111111-1111-1111-1111-111111111111",
+    "hasErrors": false,
+    "hasFailures": true,
+    "runLocation": "eu-central-1",
+    "startedAt": "2020-09-02T11:19:06.283Z",
+    "stoppedAt": "2020-09-02T11:19:06.413Z",
+    "responseTime": 240,
+    "tracerouteCheckResult": {
+        "totalHops": 12,
+        "destinationReached": false,
+        "finalHopLatency": { "avgMs": 24.1, "bestMs": 22.0, "worstMs": 31.4 },
+        "timingPhases": { "dns": 1.2, "total": 240.0 },
+        "requestError": null,
+        "request": { "url": "api.checklyhq.com", "protocol": "TCP" },
+        "assertions": [
+            { "source": "HOPS", "comparison": "LESS_THAN", "target": 10, "actual": 12 }
+        ],
+        "response": {
+            "hostname": "api.checklyhq.com",
+            "resolvedIp": "104.18.7.36",
+            "totalHops": 12,
+            "destinationReached": false,
+            "truncationReason": "max-hops",
+            "finalHopLatency": { "avgMs": 24.1 },
+            "hops": [
+                { "hop": 1, "address": "10.0.0.1", "lossPercent": 0, "rttMs": 1.1 }
+            ],
+            "protocol": "TCP",
+            "probeProtocol": "TCP"
+        }
+    },
+    "checkId": "73d29e72-6540-4bb5-967e-e07fa2c9465e",
+    "created_at": "2020-09-02T11:19:06.681Z",
+    "name": "Traceroute monitor 1",
+    "checkRunId": 1599045546010,
+    "attempts": 1,
+    "isDegraded": false,
+    "overMaxResponseTime": false
+}

--- a/fixtures/GetTracerouteMonitor.json
+++ b/fixtures/GetTracerouteMonitor.json
@@ -1,0 +1,58 @@
+{
+  "activated": false,
+  "alertChannelSubscriptions": [],
+  "alertSettings": {
+    "escalationType": "RUN_BASED",
+    "parallelRunFailureThreshold": {
+      "enabled": false,
+      "percentage": 10
+    },
+    "reminders": {
+      "amount": 0,
+      "interval": 5
+    },
+    "runBasedEscalation": {
+      "failedRunThreshold": 1
+    }
+  },
+  "checkType": "TRACEROUTE",
+  "created_at": "2025-10-30T05:34:01.240Z",
+  "degradedResponseTime": 3000,
+  "doubleCheck": false,
+  "frequency": 10,
+  "frequencyOffset": 80,
+  "groupId": null,
+  "groupOrder": null,
+  "id": "b2c3d4e5-1111-2222-3333-444455556666",
+  "locations": [
+    "us-east-1"
+  ],
+  "maxResponseTime": 5000,
+  "muted": false,
+  "name": "Traceroute Monitor #1",
+  "request": {
+    "assertions": [
+      {
+        "comparison": "LESS_THAN",
+        "property": "avg",
+        "source": "LATENCY",
+        "target": "200"
+      }
+    ],
+    "ipFamily": "IPv4",
+    "maxHops": 30,
+    "maxUnknownHops": 5,
+    "protocol": "ICMP",
+    "timeout": 30,
+    "url": "traceroute.example.com"
+  },
+  "retryStrategy": null,
+  "runParallel": false,
+  "runtimeId": null,
+  "shouldFail": false,
+  "tags": [
+    "tag-1"
+  ],
+  "triggerIncident": null,
+  "useGlobalAlertSettings": false
+}

--- a/fixtures/UpdateGRPCMonitor.json
+++ b/fixtures/UpdateGRPCMonitor.json
@@ -1,0 +1,64 @@
+{
+  "activated": false,
+  "alertChannelSubscriptions": [],
+  "alertSettings": {
+    "escalationType": "RUN_BASED",
+    "parallelRunFailureThreshold": {
+      "enabled": false,
+      "percentage": 10
+    },
+    "reminders": {
+      "amount": 0,
+      "interval": 5
+    },
+    "runBasedEscalation": {
+      "failedRunThreshold": 1
+    }
+  },
+  "checkType": "GRPC",
+  "created_at": "2025-10-30T05:34:01.240Z",
+  "degradedResponseTime": 3000,
+  "doubleCheck": false,
+  "frequency": 10,
+  "frequencyOffset": 80,
+  "groupId": null,
+  "groupOrder": null,
+  "id": "a1b2c3d4-1111-2222-3333-444455556666",
+  "locations": [
+    "us-east-1"
+  ],
+  "maxResponseTime": 5000,
+  "muted": false,
+  "name": "gRPC Monitor #1",
+  "privateLocations": [],
+  "request": {
+    "assertions": [
+      {
+        "comparison": "EQUALS",
+        "property": "",
+        "source": "GRPC_STATUS",
+        "target": "0"
+      }
+    ],
+    "grpcConfig": {
+      "method": "/grpc.health.v1.Health/Check",
+      "mode": "BEHAVIOR",
+      "storeResponseBody": false,
+      "tls": true
+    },
+    "ipFamily": "IPv4",
+    "port": 443,
+    "skipSSL": false,
+    "timeout": 30,
+    "url": "grpc.example.com"
+  },
+  "retryStrategy": null,
+  "runParallel": false,
+  "runtimeId": null,
+  "shouldFail": false,
+  "tags": [
+    "tag-1"
+  ],
+  "triggerIncident": null,
+  "useGlobalAlertSettings": false
+}

--- a/fixtures/UpdateSSLMonitor.json
+++ b/fixtures/UpdateSSLMonitor.json
@@ -1,0 +1,61 @@
+{
+  "activated": false,
+  "alertChannelSubscriptions": [],
+  "alertSettings": {
+    "escalationType": "RUN_BASED",
+    "parallelRunFailureThreshold": {
+      "enabled": false,
+      "percentage": 10
+    },
+    "reminders": {
+      "amount": 0,
+      "interval": 5
+    },
+    "runBasedEscalation": {
+      "failedRunThreshold": 1
+    }
+  },
+  "checkType": "SSL",
+  "created_at": "2025-10-30T05:34:01.240Z",
+  "doubleCheck": false,
+  "frequency": 10,
+  "frequencyOffset": 80,
+  "groupId": null,
+  "groupOrder": null,
+  "id": "c3d4e5f6-1111-2222-3333-444455556666",
+  "locations": [
+    "us-east-1"
+  ],
+  "muted": false,
+  "name": "SSL Monitor #1",
+  "privateLocations": [],
+  "request": {
+    "assertions": [
+      {
+        "comparison": "LESS_THAN",
+        "property": "",
+        "source": "CERT_DAYS_REMAINING",
+        "target": "30"
+      }
+    ],
+    "sslConfig": {
+      "alertDaysBeforeExpiry": 20,
+      "degradedResponseTimeMs": 3000,
+      "handshakeTimeoutMs": 10000,
+      "hostname": "example.com",
+      "ipFamily": "IPv4",
+      "maxResponseTimeMs": 10000,
+      "port": 443,
+      "skipChainValidation": false
+    }
+  },
+  "retryStrategy": null,
+  "runParallel": false,
+  "runtimeId": null,
+  "shouldFail": false,
+  "tags": [
+    "tag-1"
+  ],
+  "triggerIncident": null,
+  "useGlobalAlertSettings": false
+}

--- a/fixtures/UpdateSSLMonitor.json
+++ b/fixtures/UpdateSSLMonitor.json
@@ -34,10 +34,28 @@
   "request": {
     "assertions": [
       {
-        "comparison": "LESS_THAN",
-        "property": "",
-        "source": "CERT_DAYS_REMAINING",
-        "target": "30"
+        "comparison": "GREATER_THAN",
+        "property": "daysUntilExpiry",
+        "source": "CERTIFICATE",
+        "target": "14"
+      },
+      {
+        "comparison": "EQUALS",
+        "property": "tlsVersion",
+        "source": "CONNECTION",
+        "target": "TLSv1.3"
+      },
+      {
+        "comparison": "GREATER_THAN",
+        "property": "$.certificate.keySizeBits",
+        "source": "JSON_RESPONSE",
+        "target": "2048"
+      },
+      {
+        "comparison": "CONTAINS",
+        "property": "Issuer:.*Let's Encrypt",
+        "source": "TEXT_RESPONSE",
+        "target": "true"
       }
     ],
     "sslConfig": {

--- a/fixtures/UpdateSSLMonitor.json
+++ b/fixtures/UpdateSSLMonitor.json
@@ -17,6 +17,7 @@
   },
   "checkType": "SSL",
   "created_at": "2025-10-30T05:34:01.240Z",
+  "degradedResponseTime": 3000,
   "doubleCheck": false,
   "frequency": 10,
   "frequencyOffset": 80,
@@ -26,6 +27,7 @@
   "locations": [
     "us-east-1"
   ],
+  "maxResponseTime": 10000,
   "muted": false,
   "name": "SSL Monitor #1",
   "privateLocations": [],
@@ -40,11 +42,9 @@
     ],
     "sslConfig": {
       "alertDaysBeforeExpiry": 20,
-      "degradedResponseTimeMs": 3000,
       "handshakeTimeoutMs": 10000,
       "hostname": "example.com",
       "ipFamily": "IPv4",
-      "maxResponseTimeMs": 10000,
       "port": 443,
       "skipChainValidation": false
     }

--- a/fixtures/UpdateTracerouteMonitor.json
+++ b/fixtures/UpdateTracerouteMonitor.json
@@ -1,0 +1,58 @@
+{
+  "activated": false,
+  "alertChannelSubscriptions": [],
+  "alertSettings": {
+    "escalationType": "RUN_BASED",
+    "parallelRunFailureThreshold": {
+      "enabled": false,
+      "percentage": 10
+    },
+    "reminders": {
+      "amount": 0,
+      "interval": 5
+    },
+    "runBasedEscalation": {
+      "failedRunThreshold": 1
+    }
+  },
+  "checkType": "TRACEROUTE",
+  "created_at": "2025-10-30T05:34:01.240Z",
+  "degradedResponseTime": 3000,
+  "doubleCheck": false,
+  "frequency": 10,
+  "frequencyOffset": 80,
+  "groupId": null,
+  "groupOrder": null,
+  "id": "b2c3d4e5-1111-2222-3333-444455556666",
+  "locations": [
+    "us-east-1"
+  ],
+  "maxResponseTime": 5000,
+  "muted": false,
+  "name": "Traceroute Monitor #1",
+  "request": {
+    "assertions": [
+      {
+        "comparison": "LESS_THAN",
+        "property": "avg",
+        "source": "LATENCY",
+        "target": "200"
+      }
+    ],
+    "ipFamily": "IPv4",
+    "maxHops": 30,
+    "maxUnknownHops": 5,
+    "protocol": "ICMP",
+    "timeout": 30,
+    "url": "traceroute.example.com"
+  },
+  "retryStrategy": null,
+  "runParallel": false,
+  "runtimeId": null,
+  "shouldFail": false,
+  "tags": [
+    "tag-1"
+  ],
+  "triggerIncident": null,
+  "useGlobalAlertSettings": false
+}

--- a/types.go
+++ b/types.go
@@ -1251,12 +1251,12 @@ type TracerouteMonitor struct {
 // Port is stripped from the marshaled body when Protocol is "ICMP", mirroring
 // the public API's `Joi.any().strip()` for that case (see MarshalJSON).
 type TracerouteRequest struct {
-	URL            string      `json:"url"`
-	Protocol       string      `json:"protocol,omitempty"`
-	Port           int         `json:"port,omitempty"`
-	IPFamily       string      `json:"ipFamily,omitempty"`
-	MaxHops        int         `json:"maxHops,omitempty"`
-	MaxUnknownHops int         `json:"maxUnknownHops,omitempty"`
+	URL            string `json:"url"`
+	Protocol       string `json:"protocol,omitempty"`
+	Port           int    `json:"port,omitempty"`
+	IPFamily       string `json:"ipFamily,omitempty"`
+	MaxHops        int    `json:"maxHops,omitempty"`
+	MaxUnknownHops int    `json:"maxUnknownHops,omitempty"`
 	// PtrLookup is a pointer so that an explicit `false` can be sent; the API
 	// defaults it to true when the field is omitted.
 	PtrLookup  *bool       `json:"ptrLookup,omitempty"`
@@ -1609,11 +1609,16 @@ type CheckResult struct {
 	ResponseTime        int64               `json:"responseTime"`
 	ApiCheckResult      *ApiCheckResult     `json:"apiCheckResult"`
 	BrowserCheckResult  *BrowserCheckResult `json:"browserCheckResult"`
-	CheckRunID          int64               `json:"checkRunId"`
-	Attempts            int64               `json:"attempts"`
-	StartedAt           time.Time           `json:"startedAt"`
-	StoppedAt           time.Time           `json:"stoppedAt"`
-	CreatedAt           time.Time           `json:"created_at"`
+	// Typed failure-debug diagnostics for the uptime-monitor types. Each is nil
+	// for the other check types, mirroring the apiCheckResult sibling.
+	TracerouteCheckResult *TracerouteCheckResult `json:"tracerouteCheckResult"`
+	GRPCCheckResult       *GRPCCheckResult       `json:"grpcCheckResult"`
+	SSLCheckResult        *SSLCheckResult        `json:"sslCheckResult"`
+	CheckRunID            int64                  `json:"checkRunId"`
+	Attempts              int64                  `json:"attempts"`
+	StartedAt             time.Time              `json:"startedAt"`
+	StoppedAt             time.Time              `json:"stoppedAt"`
+	CreatedAt             time.Time              `json:"created_at"`
 }
 
 // ApiCheckResult represents an API Check result
@@ -1621,6 +1626,101 @@ type ApiCheckResult map[string]interface{}
 
 // BrowserCheckResult represents a Browser Check result
 type BrowserCheckResult map[string]interface{}
+
+// The TRACEROUTE / GRPC / SSL result types below mirror the additive optional
+// fields the public check-results response carries alongside apiCheckResult (see
+// the backend public-api check-results schemas). They are the read-path types an
+// SDK consumer decodes to debug a failing uptime-monitor result. Documented
+// scalars are typed; the open runner sub-objects (timingPhases / request /
+// assertions / certificate / securityBaseline) stay map/slice of interface{} so
+// the full runner artifact survives JSON decoding without dropping fields.
+
+// TracerouteCheckResult holds the failure-debug diagnostics for a traceroute
+// check result.
+type TracerouteCheckResult struct {
+	TotalHops          *int                     `json:"totalHops,omitempty"`
+	DestinationReached *bool                    `json:"destinationReached,omitempty"`
+	FinalHopLatency    map[string]interface{}   `json:"finalHopLatency,omitempty"`
+	TimingPhases       map[string]interface{}   `json:"timingPhases,omitempty"`
+	RequestError       *string                  `json:"requestError,omitempty"`
+	Request            map[string]interface{}   `json:"request,omitempty"`
+	Assertions         []map[string]interface{} `json:"assertions,omitempty"`
+	Response           *TracerouteCheckResponse `json:"response,omitempty"`
+}
+
+// TracerouteCheckResponse is the detailed traceroute response artifact.
+type TracerouteCheckResponse struct {
+	Hostname           string                   `json:"hostname,omitempty"`
+	ResolvedIP         string                   `json:"resolvedIp,omitempty"`
+	TotalHops          int                      `json:"totalHops,omitempty"`
+	DestinationReached bool                     `json:"destinationReached,omitempty"`
+	TruncationReason   string                   `json:"truncationReason,omitempty"`
+	FinalHopLatency    map[string]interface{}   `json:"finalHopLatency,omitempty"`
+	Hops               []map[string]interface{} `json:"hops,omitempty"`
+	Protocol           string                   `json:"protocol,omitempty"`
+	ProbeProtocol      string                   `json:"probeProtocol,omitempty"`
+}
+
+// GRPCCheckResult holds the failure-debug diagnostics for a gRPC check result.
+type GRPCCheckResult struct {
+	GRPCStatusCode *int                     `json:"grpcStatusCode,omitempty"`
+	HealthStatus   *int                     `json:"healthStatus,omitempty"`
+	TimingPhases   map[string]interface{}   `json:"timingPhases,omitempty"`
+	RequestError   *string                  `json:"requestError,omitempty"`
+	Request        map[string]interface{}   `json:"request,omitempty"`
+	Assertions     []map[string]interface{} `json:"assertions,omitempty"`
+	Response       *GRPCCheckResponse       `json:"response,omitempty"`
+}
+
+// GRPCCheckResponse is the detailed gRPC response artifact.
+type GRPCCheckResponse struct {
+	GRPCMode          string                 `json:"grpcMode,omitempty"`
+	Host              string                 `json:"host,omitempty"`
+	ResolvedIP        string                 `json:"resolvedIp,omitempty"`
+	Port              int                    `json:"port,omitempty"`
+	GRPCMethod        string                 `json:"grpcMethod,omitempty"`
+	ResponseMessage   string                 `json:"responseMessage,omitempty"`
+	GRPCStatusCode    int                    `json:"grpcStatusCode,omitempty"`
+	GRPCStatusMessage string                 `json:"grpcStatusMessage,omitempty"`
+	HealthStatus      *int                   `json:"healthStatus,omitempty"`
+	HealthStatusLabel string                 `json:"healthStatusLabel,omitempty"`
+	Metadata          []GRPCMetadata         `json:"metadata,omitempty"`
+	DiscoveredMethods []string               `json:"discoveredMethods,omitempty"`
+	RequestError      string                 `json:"requestError,omitempty"`
+	TimingPhases      map[string]interface{} `json:"timingPhases,omitempty"`
+}
+
+// SSLCheckResult holds the failure-debug diagnostics for an SSL check result.
+type SSLCheckResult struct {
+	TLSVersion       string                   `json:"tlsVersion,omitempty"`
+	CipherSuite      string                   `json:"cipherSuite,omitempty"`
+	DaysUntilExpiry  *int                     `json:"daysUntilExpiry,omitempty"`
+	HandshakeTimeMs  *float64                 `json:"handshakeTimeMs,omitempty"`
+	ChainTrusted     *bool                    `json:"chainTrusted,omitempty"`
+	HostnameVerified *bool                    `json:"hostnameVerified,omitempty"`
+	BaselineVerdict  string                   `json:"baselineVerdict,omitempty"`
+	BaselineGrade    string                   `json:"baselineGrade,omitempty"`
+	FailureCategory  string                   `json:"failureCategory,omitempty"`
+	RequestError     *string                  `json:"requestError,omitempty"`
+	Request          map[string]interface{}   `json:"request,omitempty"`
+	Assertions       []map[string]interface{} `json:"assertions,omitempty"`
+	Response         *SSLCheckResponse        `json:"response,omitempty"`
+}
+
+// SSLCheckResponse is the detailed SSL/TLS response artifact.
+type SSLCheckResponse struct {
+	ResolvedIP       string                   `json:"resolvedIp,omitempty"`
+	Protocol         string                   `json:"protocol,omitempty"`
+	CipherSuite      string                   `json:"cipherSuite,omitempty"`
+	HandshakeTimeMs  float64                  `json:"handshakeTimeMs,omitempty"`
+	HostnameVerified bool                     `json:"hostnameVerified,omitempty"`
+	ChainTrusted     bool                     `json:"chainTrusted,omitempty"`
+	DaysUntilExpiry  int                      `json:"daysUntilExpiry,omitempty"`
+	OCSPStapled      bool                     `json:"ocspStapled,omitempty"`
+	SecurityBaseline map[string]interface{}   `json:"securityBaseline,omitempty"`
+	Certificate      map[string]interface{}   `json:"certificate,omitempty"`
+	Chain            []map[string]interface{} `json:"chain,omitempty"`
+}
 
 // CheckResultsFilter represents the parameters that can be passed while
 // getting Check Results

--- a/types.go
+++ b/types.go
@@ -1278,11 +1278,9 @@ func (r TracerouteRequest) MarshalJSON() ([]byte, error) {
 
 // SSLMonitor represents an SSL/TLS certificate monitor.
 //
-// Unlike the other connection monitors it has no top-level
-// DegradedResponseTime/MaxResponseTime fields: the SSL response-time limits are
-// nested inside the request as `degradedResponseTimeMs`/`maxResponseTimeMs` on
-// the SSLConfig (the public create schema spreads no top-level response-time
-// fields for SSL). SSL monitors do support private locations.
+// Like the other connection monitors (gRPC, traceroute), the response-time
+// thresholds are top-level DegradedResponseTime/MaxResponseTime fields. SSL
+// monitors do support private locations.
 type SSLMonitor struct {
 	ID                        string                     `json:"id,omitempty"`
 	Name                      string                     `json:"name"`
@@ -1294,6 +1292,8 @@ type SSLMonitor struct {
 	ShouldFail                bool                       `json:"shouldFail"`
 	RunParallel               bool                       `json:"runParallel"`
 	Locations                 []string                   `json:"locations"`
+	DegradedResponseTime      int                        `json:"degradedResponseTime,omitempty"`
+	MaxResponseTime           int                        `json:"maxResponseTime,omitempty"`
 	Tags                      []string                   `json:"tags,omitempty"`
 	AlertSettings             *AlertSettings             `json:"alertSettings,omitempty"`
 	UseGlobalAlertSettings    bool                       `json:"useGlobalAlertSettings"`
@@ -1323,8 +1323,7 @@ type SSLRequest struct {
 }
 
 // SSLConfig represents the SSL-specific configuration nested inside an SSL
-// monitor's request. The response-time limits live here (not at the top level
-// like the other monitor types). SecurityBaseline is an optional pointer:
+// monitor's request. SecurityBaseline is an optional pointer:
 // leave it nil to inherit the server-side default baseline.
 type SSLConfig struct {
 	Hostname string `json:"hostname"`
@@ -1337,9 +1336,7 @@ type SSLConfig struct {
 	AlertDaysBeforeExpiry int               `json:"alertDaysBeforeExpiry,omitempty"`
 	SecurityBaseline      *SecurityBaseline `json:"securityBaseline,omitempty"`
 	// ClientCertificateMode is "auto" or "explicit" (optional).
-	ClientCertificateMode  string `json:"clientCertificateMode,omitempty"`
-	DegradedResponseTimeMs int    `json:"degradedResponseTimeMs,omitempty"`
-	MaxResponseTimeMs      int    `json:"maxResponseTimeMs,omitempty"`
+	ClientCertificateMode string `json:"clientCertificateMode,omitempty"`
 }
 
 // SecurityBaseline represents the SSL security baseline — a set of enforceable

--- a/types.go
+++ b/types.go
@@ -809,6 +809,22 @@ const ResponseTime = "RESPONSE_TIME"
 // ResponseData identifies the response data of a TCP check as an assertion source.
 const ResponseData = "RESPONSE_DATA"
 
+// Certificate identifies a certificate field selector (via the assertion
+// property) as an assertion source, for use with an SSL monitor.
+const Certificate = "CERTIFICATE"
+
+// Connection identifies a connection/handshake field selector (via the
+// assertion property) as an assertion source, for use with an SSL monitor.
+const Connection = "CONNECTION"
+
+// JSONResponse identifies a JSONPath over the response (via the assertion
+// property) as an assertion source, for use with SSL, ICMP and DNS monitors.
+const JSONResponse = "JSON_RESPONSE"
+
+// TextResponse identifies a regex applied to the serialized response (via the
+// assertion property) as an assertion source, for use with an SSL monitor.
+const TextResponse = "TEXT_RESPONSE"
+
 // Assertion comparison constants
 
 // Equals asserts that the source and target are equal.
@@ -834,6 +850,12 @@ const Contains = "CONTAINS"
 
 // NotContains asserts that the source does not contain a specified value.
 const NotContains = "NOT_CONTAINS"
+
+// IsNull asserts that the source is null.
+const IsNull = "IS_NULL"
+
+// NotNull asserts that the source is not null.
+const NotNull = "NOT_NULL"
 
 // Check represents the parameters for an existing check.
 type Check struct {
@@ -1195,10 +1217,9 @@ type GRPCRequest struct {
 // the "HEALTH" mode forbids the BEHAVIOR-only fields, so they are tagged
 // omitempty to drop them from the marshaled body when unset.
 type GRPCConfig struct {
-	Mode              string         `json:"mode,omitempty"`
-	TLS               bool           `json:"tls"`
-	Metadata          []GRPCMetadata `json:"metadata,omitempty"`
-	StoreResponseBody bool           `json:"storeResponseBody"`
+	Mode     string         `json:"mode,omitempty"`
+	TLS      bool           `json:"tls"`
+	Metadata []GRPCMetadata `json:"metadata,omitempty"`
 	// BEHAVIOR-mode only (forbidden in HEALTH mode).
 	ServiceDefinition string `json:"serviceDefinition,omitempty"`
 	Method            string `json:"method,omitempty"`

--- a/types.go
+++ b/types.go
@@ -103,6 +103,13 @@ type Client interface {
 		monitor TCPMonitor,
 	) (*TCPMonitor, error)
 
+	// CreateGRPCMonitor creates a new gRPC monitor with the specified details.
+	// It returns the newly-created monitor, or an error.
+	CreateGRPCMonitor(
+		ctx context.Context,
+		monitor GRPCMonitor,
+	) (*GRPCMonitor, error)
+
 	// CreateURLMonitor creates a new URL monitor with the specified details.
 	// It returns the newly-created monitor, or an error.
 	CreateURLMonitor(
@@ -172,6 +179,14 @@ type Client interface {
 		monitor TCPMonitor,
 	) (*TCPMonitor, error)
 
+	// UpdateGRPCMonitor updates an existing gRPC monitor with the specified
+	// details. It returns the updated monitor, or an error.
+	UpdateGRPCMonitor(
+		ctx context.Context,
+		ID string,
+		monitor GRPCMonitor,
+	) (*GRPCMonitor, error)
+
 	// UpdateURLMonitor updates an existing URL monitor with the specified details.
 	// It returns the updated monitor, or an error.
 	UpdateURLMonitor(
@@ -217,6 +232,12 @@ type Client interface {
 
 	// DeleteTCPMonitor deletes the monitor with the specified ID.
 	DeleteTCPMonitor(
+		ctx context.Context,
+		ID string,
+	) error
+
+	// DeleteGRPCMonitor deletes the monitor with the specified ID.
+	DeleteGRPCMonitor(
 		ctx context.Context,
 		ID string,
 	) error
@@ -267,6 +288,13 @@ type Client interface {
 		ctx context.Context,
 		ID string,
 	) (*TCPMonitor, error)
+
+	// Get takes the ID of an existing gRPC monitor, and returns the monitor
+	// parameters, or an error.
+	GetGRPCMonitor(
+		ctx context.Context,
+		ID string,
+	) (*GRPCMonitor, error)
 
 	// Get takes the ID of an existing URL monitor, and returns the monitor
 	// parameters, or an error.
@@ -1059,6 +1087,75 @@ type TCPRequest struct {
 	Data       string      `json:"data,omitempty"`
 	Assertions []Assertion `json:"assertions,omitempty"`
 	IPFamily   string      `json:"ipFamily,omitempty"`
+}
+
+// GRPCMonitor represents a gRPC monitor.
+type GRPCMonitor struct {
+	ID                        string                     `json:"id,omitempty"`
+	Name                      string                     `json:"name"`
+	Description               *string                    `json:"description"`
+	Frequency                 int                        `json:"frequency"`
+	FrequencyOffset           int                        `json:"frequencyOffset,omitempty"`
+	Activated                 bool                       `json:"activated"`
+	Muted                     bool                       `json:"muted"`
+	ShouldFail                bool                       `json:"shouldFail"`
+	RunParallel               bool                       `json:"runParallel"`
+	Locations                 []string                   `json:"locations"`
+	DegradedResponseTime      int                        `json:"degradedResponseTime,omitempty"`
+	MaxResponseTime           int                        `json:"maxResponseTime,omitempty"`
+	Tags                      []string                   `json:"tags,omitempty"`
+	AlertSettings             *AlertSettings             `json:"alertSettings,omitempty"`
+	UseGlobalAlertSettings    bool                       `json:"useGlobalAlertSettings"`
+	Request                   GRPCRequest                `json:"request"`
+	GroupID                   int64                      `json:"groupId,omitempty"`
+	GroupOrder                int                        `json:"groupOrder,omitempty"`
+	AlertChannelSubscriptions []AlertChannelSubscription `json:"alertChannelSubscriptions,omitempty"`
+	PrivateLocations          *[]string                  `json:"privateLocations"`
+	RuntimeID                 *string                    `json:"runtimeId"`
+	RetryStrategy             *RetryStrategy             `json:"retryStrategy"`
+	TriggerIncident           *IncidentTrigger           `json:"triggerIncident"`
+	CreatedAt                 time.Time                  `json:"created_at,omitempty"`
+	UpdatedAt                 time.Time                  `json:"updated_at,omitempty"`
+}
+
+// GRPCRequest represents the parameters for a gRPC monitor's connection.
+//
+// GRPCConfig is required by the public API (the wire schema is `.required()`),
+// so it is sent as a value rather than an optional pointer.
+type GRPCRequest struct {
+	URL string `json:"url"`
+	// Port accepts a number or a `{{template}}` string, mirroring the public
+	// API's `Joi.alternatives`, so its type is intentionally open.
+	Port       interface{} `json:"port"`
+	IPFamily   string      `json:"ipFamily,omitempty"`
+	SkipSSL    bool        `json:"skipSSL"`
+	Timeout    int         `json:"timeout,omitempty"`
+	GRPCConfig GRPCConfig  `json:"grpcConfig"`
+	Assertions []Assertion `json:"assertions,omitempty"`
+}
+
+// GRPCConfig represents the gRPC-specific configuration nested inside a gRPC
+// monitor's request. `Mode` defaults to "BEHAVIOR" (which requires `Method`);
+// the "HEALTH" mode forbids the BEHAVIOR-only fields, so they are tagged
+// omitempty to drop them from the marshaled body when unset.
+type GRPCConfig struct {
+	Mode              string         `json:"mode,omitempty"`
+	TLS               bool           `json:"tls"`
+	Metadata          []GRPCMetadata `json:"metadata,omitempty"`
+	StoreResponseBody bool           `json:"storeResponseBody"`
+	// BEHAVIOR-mode only (forbidden in HEALTH mode).
+	ServiceDefinition string `json:"serviceDefinition,omitempty"`
+	Method            string `json:"method,omitempty"`
+	ProtoContent      string `json:"protoContent,omitempty"`
+	Message           string `json:"message,omitempty"`
+	// HEALTH-mode only (forbidden in BEHAVIOR mode).
+	Service string `json:"service,omitempty"`
+}
+
+// GRPCMetadata represents a single gRPC metadata key/value pair.
+type GRPCMetadata struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // EnvironmentVariable represents a key-value pair for setting environment

--- a/types.go
+++ b/types.go
@@ -117,6 +117,13 @@ type Client interface {
 		monitor TracerouteMonitor,
 	) (*TracerouteMonitor, error)
 
+	// CreateSSLMonitor creates a new SSL monitor with the specified details.
+	// It returns the newly-created monitor, or an error.
+	CreateSSLMonitor(
+		ctx context.Context,
+		monitor SSLMonitor,
+	) (*SSLMonitor, error)
+
 	// CreateURLMonitor creates a new URL monitor with the specified details.
 	// It returns the newly-created monitor, or an error.
 	CreateURLMonitor(
@@ -202,6 +209,14 @@ type Client interface {
 		monitor TracerouteMonitor,
 	) (*TracerouteMonitor, error)
 
+	// UpdateSSLMonitor updates an existing SSL monitor with the specified
+	// details. It returns the updated monitor, or an error.
+	UpdateSSLMonitor(
+		ctx context.Context,
+		ID string,
+		monitor SSLMonitor,
+	) (*SSLMonitor, error)
+
 	// UpdateURLMonitor updates an existing URL monitor with the specified details.
 	// It returns the updated monitor, or an error.
 	UpdateURLMonitor(
@@ -259,6 +274,12 @@ type Client interface {
 
 	// DeleteTracerouteMonitor deletes the monitor with the specified ID.
 	DeleteTracerouteMonitor(
+		ctx context.Context,
+		ID string,
+	) error
+
+	// DeleteSSLMonitor deletes the monitor with the specified ID.
+	DeleteSSLMonitor(
 		ctx context.Context,
 		ID string,
 	) error
@@ -323,6 +344,13 @@ type Client interface {
 		ctx context.Context,
 		ID string,
 	) (*TracerouteMonitor, error)
+
+	// Get takes the ID of an existing SSL monitor, and returns the monitor
+	// parameters, or an error.
+	GetSSLMonitor(
+		ctx context.Context,
+		ID string,
+	) (*SSLMonitor, error)
 
 	// Get takes the ID of an existing URL monitor, and returns the monitor
 	// parameters, or an error.
@@ -1246,6 +1274,110 @@ func (r TracerouteRequest) MarshalJSON() ([]byte, error) {
 		r.Port = 0
 	}
 	return json.Marshal(alias(r))
+}
+
+// SSLMonitor represents an SSL/TLS certificate monitor.
+//
+// Unlike the other connection monitors it has no top-level
+// DegradedResponseTime/MaxResponseTime fields: the SSL response-time limits are
+// nested inside the request as `degradedResponseTimeMs`/`maxResponseTimeMs` on
+// the SSLConfig (the public create schema spreads no top-level response-time
+// fields for SSL). SSL monitors do support private locations.
+type SSLMonitor struct {
+	ID                        string                     `json:"id,omitempty"`
+	Name                      string                     `json:"name"`
+	Description               *string                    `json:"description"`
+	Frequency                 int                        `json:"frequency"`
+	FrequencyOffset           int                        `json:"frequencyOffset,omitempty"`
+	Activated                 bool                       `json:"activated"`
+	Muted                     bool                       `json:"muted"`
+	ShouldFail                bool                       `json:"shouldFail"`
+	RunParallel               bool                       `json:"runParallel"`
+	Locations                 []string                   `json:"locations"`
+	Tags                      []string                   `json:"tags,omitempty"`
+	AlertSettings             *AlertSettings             `json:"alertSettings,omitempty"`
+	UseGlobalAlertSettings    bool                       `json:"useGlobalAlertSettings"`
+	Request                   SSLRequest                 `json:"request"`
+	GroupID                   int64                      `json:"groupId,omitempty"`
+	GroupOrder                int                        `json:"groupOrder,omitempty"`
+	AlertChannelSubscriptions []AlertChannelSubscription `json:"alertChannelSubscriptions,omitempty"`
+	PrivateLocations          *[]string                  `json:"privateLocations"`
+	RuntimeID                 *string                    `json:"runtimeId"`
+	RetryStrategy             *RetryStrategy             `json:"retryStrategy"`
+	TriggerIncident           *IncidentTrigger           `json:"triggerIncident"`
+	CreatedAt                 time.Time                  `json:"created_at,omitempty"`
+	UpdatedAt                 time.Time                  `json:"updated_at,omitempty"`
+}
+
+// SSLRequest represents the parameters for an SSL monitor's connection.
+//
+// SSLConfig is required by the public API (the wire schema is `.required()`),
+// so it is sent as a value rather than an optional pointer.
+type SSLRequest struct {
+	SSLConfig SSLConfig `json:"sslConfig"`
+	// SSLClientCertificateId is the FK to a stored client certificate. It is
+	// required when SSLConfig.ClientCertificateMode is "explicit" and omitted
+	// otherwise, so it is a pointer with omitempty.
+	SSLClientCertificateId *string     `json:"sslClientCertificateId,omitempty"`
+	Assertions             []Assertion `json:"assertions,omitempty"`
+}
+
+// SSLConfig represents the SSL-specific configuration nested inside an SSL
+// monitor's request. The response-time limits live here (not at the top level
+// like the other monitor types). SecurityBaseline is an optional pointer:
+// leave it nil to inherit the server-side default baseline.
+type SSLConfig struct {
+	Hostname string `json:"hostname"`
+	Port     int    `json:"port,omitempty"`
+	// ServerName is an optional SNI override (nullable in the API).
+	ServerName            *string           `json:"serverName,omitempty"`
+	IPFamily              string            `json:"ipFamily,omitempty"`
+	SkipChainValidation   bool              `json:"skipChainValidation"`
+	HandshakeTimeoutMs    int               `json:"handshakeTimeoutMs,omitempty"`
+	AlertDaysBeforeExpiry int               `json:"alertDaysBeforeExpiry,omitempty"`
+	SecurityBaseline      *SecurityBaseline `json:"securityBaseline,omitempty"`
+	// ClientCertificateMode is "auto" or "explicit" (optional).
+	ClientCertificateMode  string `json:"clientCertificateMode,omitempty"`
+	DegradedResponseTimeMs int    `json:"degradedResponseTimeMs,omitempty"`
+	MaxResponseTimeMs      int    `json:"maxResponseTimeMs,omitempty"`
+}
+
+// SecurityBaseline represents the SSL security baseline — a set of enforceable
+// and advisory rules, each with an optional value and a severity. Construct one
+// only to override the server defaults; a nil *SecurityBaseline on SSLConfig
+// inherits them. Enabled is a pointer so an explicit `false` can be sent while
+// an unset value is omitted (the server defaults it to true).
+type SecurityBaseline struct {
+	Enabled *bool `json:"enabled,omitempty"`
+	// Enforceable rules — server default severity "fail".
+	MinTLSVersion          *SSLBaselineTLSRule      `json:"minTLSVersion,omitempty"`
+	MinKeySizeBits         *SSLBaselineKeySizeRule  `json:"minKeySizeBits,omitempty"`
+	WeakSignatureAlgorithm *SSLBaselineSeverityRule `json:"weakSignatureAlgorithm,omitempty"`
+	WeakCipherSuite        *SSLBaselineSeverityRule `json:"weakCipherSuite,omitempty"`
+	KnownBadCA             *SSLBaselineSeverityRule `json:"knownBadCA,omitempty"`
+	// Advisory rules — server default severity "ignore".
+	RecommendedTLSVersion   *SSLBaselineTLSRule      `json:"recommendedTLSVersion,omitempty"`
+	RecommendedKeySizeBits  *SSLBaselineKeySizeRule  `json:"recommendedKeySizeBits,omitempty"`
+	OCSPMustStapleRespected *SSLBaselineSeverityRule `json:"ocspMustStapleRespected,omitempty"`
+	SCTPresent              *SSLBaselineSeverityRule `json:"sctPresent,omitempty"`
+}
+
+// SSLBaselineTLSRule is a baseline rule whose value is a TLS version string
+// (e.g. "TLS1.2"/"TLS1.3").
+type SSLBaselineTLSRule struct {
+	Value    string `json:"value,omitempty"`
+	Severity string `json:"severity,omitempty"`
+}
+
+// SSLBaselineKeySizeRule is a baseline rule whose value is a key size in bits.
+type SSLBaselineKeySizeRule struct {
+	Value    int    `json:"value,omitempty"`
+	Severity string `json:"severity,omitempty"`
+}
+
+// SSLBaselineSeverityRule is a baseline rule that only carries a severity.
+type SSLBaselineSeverityRule struct {
+	Severity string `json:"severity,omitempty"`
 }
 
 // EnvironmentVariable represents a key-value pair for setting environment

--- a/types.go
+++ b/types.go
@@ -110,6 +110,13 @@ type Client interface {
 		monitor GRPCMonitor,
 	) (*GRPCMonitor, error)
 
+	// CreateTracerouteMonitor creates a new traceroute monitor with the
+	// specified details. It returns the newly-created monitor, or an error.
+	CreateTracerouteMonitor(
+		ctx context.Context,
+		monitor TracerouteMonitor,
+	) (*TracerouteMonitor, error)
+
 	// CreateURLMonitor creates a new URL monitor with the specified details.
 	// It returns the newly-created monitor, or an error.
 	CreateURLMonitor(
@@ -187,6 +194,14 @@ type Client interface {
 		monitor GRPCMonitor,
 	) (*GRPCMonitor, error)
 
+	// UpdateTracerouteMonitor updates an existing traceroute monitor with the
+	// specified details. It returns the updated monitor, or an error.
+	UpdateTracerouteMonitor(
+		ctx context.Context,
+		ID string,
+		monitor TracerouteMonitor,
+	) (*TracerouteMonitor, error)
+
 	// UpdateURLMonitor updates an existing URL monitor with the specified details.
 	// It returns the updated monitor, or an error.
 	UpdateURLMonitor(
@@ -238,6 +253,12 @@ type Client interface {
 
 	// DeleteGRPCMonitor deletes the monitor with the specified ID.
 	DeleteGRPCMonitor(
+		ctx context.Context,
+		ID string,
+	) error
+
+	// DeleteTracerouteMonitor deletes the monitor with the specified ID.
+	DeleteTracerouteMonitor(
 		ctx context.Context,
 		ID string,
 	) error
@@ -295,6 +316,13 @@ type Client interface {
 		ctx context.Context,
 		ID string,
 	) (*GRPCMonitor, error)
+
+	// Get takes the ID of an existing traceroute monitor, and returns the
+	// monitor parameters, or an error.
+	GetTracerouteMonitor(
+		ctx context.Context,
+		ID string,
+	) (*TracerouteMonitor, error)
 
 	// Get takes the ID of an existing URL monitor, and returns the monitor
 	// parameters, or an error.
@@ -1156,6 +1184,68 @@ type GRPCConfig struct {
 type GRPCMetadata struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
+}
+
+// TracerouteMonitor represents a traceroute monitor.
+//
+// Unlike the other monitor types it has no PrivateLocations field: the public
+// create schema marks `privateLocations` as forbidden ("Traceroute monitors do
+// not support private locations"), so the field must never reach the wire.
+type TracerouteMonitor struct {
+	ID                        string                     `json:"id,omitempty"`
+	Name                      string                     `json:"name"`
+	Description               *string                    `json:"description"`
+	Frequency                 int                        `json:"frequency"`
+	FrequencyOffset           int                        `json:"frequencyOffset,omitempty"`
+	Activated                 bool                       `json:"activated"`
+	Muted                     bool                       `json:"muted"`
+	ShouldFail                bool                       `json:"shouldFail"`
+	RunParallel               bool                       `json:"runParallel"`
+	Locations                 []string                   `json:"locations"`
+	DegradedResponseTime      int                        `json:"degradedResponseTime,omitempty"`
+	MaxResponseTime           int                        `json:"maxResponseTime,omitempty"`
+	Tags                      []string                   `json:"tags,omitempty"`
+	AlertSettings             *AlertSettings             `json:"alertSettings,omitempty"`
+	UseGlobalAlertSettings    bool                       `json:"useGlobalAlertSettings"`
+	Request                   TracerouteRequest          `json:"request"`
+	GroupID                   int64                      `json:"groupId,omitempty"`
+	GroupOrder                int                        `json:"groupOrder,omitempty"`
+	AlertChannelSubscriptions []AlertChannelSubscription `json:"alertChannelSubscriptions,omitempty"`
+	RuntimeID                 *string                    `json:"runtimeId"`
+	RetryStrategy             *RetryStrategy             `json:"retryStrategy"`
+	TriggerIncident           *IncidentTrigger           `json:"triggerIncident"`
+	CreatedAt                 time.Time                  `json:"created_at,omitempty"`
+	UpdatedAt                 time.Time                  `json:"updated_at,omitempty"`
+}
+
+// TracerouteRequest represents the parameters for a traceroute monitor's probe.
+//
+// Port is stripped from the marshaled body when Protocol is "ICMP", mirroring
+// the public API's `Joi.any().strip()` for that case (see MarshalJSON).
+type TracerouteRequest struct {
+	URL            string      `json:"url"`
+	Protocol       string      `json:"protocol,omitempty"`
+	Port           int         `json:"port,omitempty"`
+	IPFamily       string      `json:"ipFamily,omitempty"`
+	MaxHops        int         `json:"maxHops,omitempty"`
+	MaxUnknownHops int         `json:"maxUnknownHops,omitempty"`
+	// PtrLookup is a pointer so that an explicit `false` can be sent; the API
+	// defaults it to true when the field is omitted.
+	PtrLookup  *bool       `json:"ptrLookup,omitempty"`
+	Timeout    int         `json:"timeout,omitempty"`
+	Assertions []Assertion `json:"assertions,omitempty"`
+}
+
+// MarshalJSON drops the `port` field when the probe protocol is "ICMP",
+// mirroring the public API schema which strips `port` for ICMP traceroutes.
+func (r TracerouteRequest) MarshalJSON() ([]byte, error) {
+	type alias TracerouteRequest
+	if r.Protocol == "ICMP" {
+		// Zero value combined with the `omitempty` tag drops `port` from the
+		// marshaled body, matching the Joi `.strip()` behavior.
+		r.Port = 0
+	}
+	return json.Marshal(alias(r))
 }
 
 // EnvironmentVariable represents a key-value pair for setting environment


### PR DESCRIPTION
## Summary
- Adds SDK monitor/check types for gRPC, SSL, and traceroute.
- Adds result payload models for typed diagnostics returned by the public API.
- Adds create/update/read tests and JSON fixture coverage for the new typed resources.

## Testing
- Source branch validation for the SDK changes is tracked in the split rollout tracker.
