### PR TITLE
feat(ssl): property-scoped assertion grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <br>
 
+## [Unreleased]
+### Added
+- Add SSL assertion grammar: new assertion sources `CERTIFICATE`, `CONNECTION`, `RESPONSE_TIME`, `JSON_RESPONSE` and `TEXT_RESPONSE`, plus `IS_NULL`/`NOT_NULL` comparisons
+
 ## [v1.22.0](https://github.com/checkly/checkly-go-sdk/releases/tag/v1.22.0) - 2026-06-25
 ### Added
 - Add `GRPCMonitor` type + `Create/Get/Update/Delete` client methods (`checks/grpc`) [#c0f841a](https://github.com/checkly/checkly-go-sdk/commit/c0f841a)

--- a/checkly_test.go
+++ b/checkly_test.go
@@ -2738,10 +2738,28 @@ var testSSLMonitor = checkly.SSLMonitor{
 		},
 		Assertions: []checkly.Assertion{
 			{
-				Source:     "CERT_DAYS_REMAINING",
-				Target:     "30",
-				Property:   "",
-				Comparison: "LESS_THAN",
+				Source:     checkly.Certificate,
+				Property:   "daysUntilExpiry",
+				Comparison: checkly.GreaterThan,
+				Target:     "14",
+			},
+			{
+				Source:     checkly.Connection,
+				Property:   "tlsVersion",
+				Comparison: checkly.Equals,
+				Target:     "TLSv1.3",
+			},
+			{
+				Source:     checkly.JSONResponse,
+				Property:   "$.certificate.keySizeBits",
+				Comparison: checkly.GreaterThan,
+				Target:     "2048",
+			},
+			{
+				Source:     checkly.TextResponse,
+				Property:   "Issuer:.*Let's Encrypt",
+				Comparison: checkly.Contains,
+				Target:     "true",
 			},
 		},
 	},

--- a/fixtures/CreateSSLMonitor.json
+++ b/fixtures/CreateSSLMonitor.json
@@ -34,10 +34,28 @@
   "request": {
     "assertions": [
       {
-        "comparison": "LESS_THAN",
-        "property": "",
-        "source": "CERT_DAYS_REMAINING",
-        "target": "30"
+        "comparison": "GREATER_THAN",
+        "property": "daysUntilExpiry",
+        "source": "CERTIFICATE",
+        "target": "14"
+      },
+      {
+        "comparison": "EQUALS",
+        "property": "tlsVersion",
+        "source": "CONNECTION",
+        "target": "TLSv1.3"
+      },
+      {
+        "comparison": "GREATER_THAN",
+        "property": "$.certificate.keySizeBits",
+        "source": "JSON_RESPONSE",
+        "target": "2048"
+      },
+      {
+        "comparison": "CONTAINS",
+        "property": "Issuer:.*Let's Encrypt",
+        "source": "TEXT_RESPONSE",
+        "target": "true"
       }
     ],
     "sslConfig": {

--- a/fixtures/GetSSLMonitor.json
+++ b/fixtures/GetSSLMonitor.json
@@ -34,10 +34,28 @@
   "request": {
     "assertions": [
       {
-        "comparison": "LESS_THAN",
-        "property": "",
-        "source": "CERT_DAYS_REMAINING",
-        "target": "30"
+        "comparison": "GREATER_THAN",
+        "property": "daysUntilExpiry",
+        "source": "CERTIFICATE",
+        "target": "14"
+      },
+      {
+        "comparison": "EQUALS",
+        "property": "tlsVersion",
+        "source": "CONNECTION",
+        "target": "TLSv1.3"
+      },
+      {
+        "comparison": "GREATER_THAN",
+        "property": "$.certificate.keySizeBits",
+        "source": "JSON_RESPONSE",
+        "target": "2048"
+      },
+      {
+        "comparison": "CONTAINS",
+        "property": "Issuer:.*Let's Encrypt",
+        "source": "TEXT_RESPONSE",
+        "target": "true"
       }
     ],
     "sslConfig": {

--- a/fixtures/UpdateSSLMonitor.json
+++ b/fixtures/UpdateSSLMonitor.json
@@ -34,10 +34,28 @@
   "request": {
     "assertions": [
       {
-        "comparison": "LESS_THAN",
-        "property": "",
-        "source": "CERT_DAYS_REMAINING",
-        "target": "30"
+        "comparison": "GREATER_THAN",
+        "property": "daysUntilExpiry",
+        "source": "CERTIFICATE",
+        "target": "14"
+      },
+      {
+        "comparison": "EQUALS",
+        "property": "tlsVersion",
+        "source": "CONNECTION",
+        "target": "TLSv1.3"
+      },
+      {
+        "comparison": "GREATER_THAN",
+        "property": "$.certificate.keySizeBits",
+        "source": "JSON_RESPONSE",
+        "target": "2048"
+      },
+      {
+        "comparison": "CONTAINS",
+        "property": "Issuer:.*Let's Encrypt",
+        "source": "TEXT_RESPONSE",
+        "target": "true"
       }
     ],
     "sslConfig": {

--- a/types.go
+++ b/types.go
@@ -809,6 +809,22 @@ const ResponseTime = "RESPONSE_TIME"
 // ResponseData identifies the response data of a TCP check as an assertion source.
 const ResponseData = "RESPONSE_DATA"
 
+// Certificate identifies a certificate field selector (via the assertion
+// property) as an assertion source, for use with an SSL monitor.
+const Certificate = "CERTIFICATE"
+
+// Connection identifies a connection/handshake field selector (via the
+// assertion property) as an assertion source, for use with an SSL monitor.
+const Connection = "CONNECTION"
+
+// JSONResponse identifies a JSONPath over the response (via the assertion
+// property) as an assertion source, for use with SSL, ICMP and DNS monitors.
+const JSONResponse = "JSON_RESPONSE"
+
+// TextResponse identifies a regex applied to the serialized response (via the
+// assertion property) as an assertion source, for use with an SSL monitor.
+const TextResponse = "TEXT_RESPONSE"
+
 // Assertion comparison constants
 
 // Equals asserts that the source and target are equal.
@@ -834,6 +850,12 @@ const Contains = "CONTAINS"
 
 // NotContains asserts that the source does not contain a specified value.
 const NotContains = "NOT_CONTAINS"
+
+// IsNull asserts that the source is null.
+const IsNull = "IS_NULL"
+
+// NotNull asserts that the source is not null.
+const NotNull = "NOT_NULL"
 
 // Check represents the parameters for an existing check.
 type Check struct {

--- a/types.go
+++ b/types.go
@@ -1217,10 +1217,9 @@ type GRPCRequest struct {
 // the "HEALTH" mode forbids the BEHAVIOR-only fields, so they are tagged
 // omitempty to drop them from the marshaled body when unset.
 type GRPCConfig struct {
-	Mode              string         `json:"mode,omitempty"`
-	TLS               bool           `json:"tls"`
-	Metadata          []GRPCMetadata `json:"metadata,omitempty"`
-	StoreResponseBody bool           `json:"storeResponseBody"`
+	Mode     string         `json:"mode,omitempty"`
+	TLS      bool           `json:"tls"`
+	Metadata []GRPCMetadata `json:"metadata,omitempty"`
 	// BEHAVIOR-mode only (forbidden in HEALTH mode).
 	ServiceDefinition string `json:"serviceDefinition,omitempty"`
 	Method            string `json:"method,omitempty"`


### PR DESCRIPTION
## What
Updates the SSL monitor assertion grammar to the new **property-scoped** model (matching the go-runner / backend / webapp change in the monorepo).

- Adds assertion **source** consts: `CERTIFICATE`, `CONNECTION` (each with a `property` field selector), `JSON_RESPONSE` (property = JSONPath), `TEXT_RESPONSE` (property = regex). `RESPONSE_TIME` already existed and is reused.
- Adds **comparison** consts `IS_NULL`, `NOT_NULL`.
- Migrates the SSL monitor test + `fixtures/*SSLMonitor.json` off the old flat grammar (`CERT_DAYS_REMAINING`) to the new `{source, property, comparison, target}` shape.
- CHANGELOG entry.

The generic `Assertion` struct already carries `Source`/`Property`/`Comparison`/`Target`, so no structural change was needed — this is consts + test/fixture migration.

## Base branch
Based on **`feat/traceroute-monitor-types`**, where the SSL monitor type lives (it isn't on `main` yet), so the diff is only the grammar change.

## Other changes
- Drops `StoreResponseBody` from `GRPCConfig`: the backend removed the per-check "store response body" toggle (gRPC checks always store the body now), so the field is removed before this branch ships in a released SDK.

## Tests
`go build`, `go vet`, `go test ./...` green — the SSL create/update/get tests round-trip the new-grammar assertions against the updated fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
