### PR TITLE
chore: update dependencies (go-cmp v0.7.0, CI actions) [RED-811]

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,15 +23,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Zip Release
-        uses: thedoctor0/zip-release@master
+        uses: thedoctor0/zip-release@0.7.6
         with:
           filename: checkly-go-sdk.zip
           exclusions: "*.git* *_test.go /*fixtures/* /*demo/* MAKEFILE"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v7
         with:
           go-version-file: "go.mod"
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/checkly/checkly-go-sdk
 
-go 1.18
+go 1.21
 
-require github.com/google/go-cmp v0.5.9
+require github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=


### PR DESCRIPTION
Linear: RED-811

Updates all dependencies of the SDK.

## Go modules

- Bump `github.com/google/go-cmp` v0.5.9 → v0.7.0 (the SDK's only dependency, test-only).
- Raise the `go` directive from 1.18 to 1.21, required because go-cmp v0.7.0 declares `go 1.21`. **Consumers of the SDK will need a Go ≥ 1.21 toolchain.**

`go build ./...` and `go test ./...` pass with the updated modules.

## GitHub Actions

- `actions/checkout` v3 → v7
- `actions/setup-go` v3 → v7
- `github/codeql-action` v2 → v4 — v2 has been deprecated and disabled by GitHub, so the CodeQL workflow was likely already failing
- `thedoctor0/zip-release` `@master` → pinned `@0.7.6`
- `ncipollo/release-action@v1` is already on the latest major; unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
