### PR TITLE
feat: add Timezone and pause/silence scope to MaintenanceWindow

### DIFF
--- a/checkly_test.go
+++ b/checkly_test.go
@@ -1331,17 +1331,28 @@ func validateMaintenanceWindow(t *testing.T, body []byte) {
 	}
 }
 
+// Covers both pointer states: pause is true, silence is an explicit false,
+// which must still be transmitted rather than omitted.
+var (
+	testMaintenanceWindowPauseAllChecks   = true
+	testMaintenanceWindowSilenceAllAlerts = false
+)
+
 var testMaintenanceWindow = checkly.MaintenanceWindow{
-	ID:             1,
-	Name:           "TEST",
-	StartsAt:       "2014-08-24T00:00:00.000Z",
-	EndsAt:         "2014-08-24T00:00:00.000Z",
-	RepeatUnit:     "MONTH",
-	RepeatEndsAt:   "2014-08-24T00:00:00.000Z",
-	RepeatInterval: 10,
-	CreatedAt:      "2013-08-24",
-	UpdatedAt:      "2014-08-24",
-	Tags:           []string{"string"},
+	ID:                1,
+	Name:              "TEST",
+	StartsAt:          "2014-08-24T00:00:00.000Z",
+	EndsAt:            "2014-08-24T00:00:00.000Z",
+	RepeatUnit:        "MONTH",
+	RepeatEndsAt:      "2014-08-24T00:00:00.000Z",
+	RepeatInterval:    10,
+	CreatedAt:         "2013-08-24",
+	UpdatedAt:         "2014-08-24",
+	Tags:              []string{"string"},
+	Timezone:          "America/New_York",
+	PauseAllChecks:    &testMaintenanceWindowPauseAllChecks,
+	SilenceAlertsTags: []string{"string"},
+	SilenceAllAlerts:  &testMaintenanceWindowSilenceAllAlerts,
 }
 
 var ignoreMaintenanceWindowFields = cmpopts.IgnoreFields(checkly.MaintenanceWindow{}, "ID", "CreatedAt", "UpdatedAt")

--- a/fixtures/CreateMaintenanceWindow.json
+++ b/fixtures/CreateMaintenanceWindow.json
@@ -7,5 +7,9 @@
 	"repeatInterval": 10,
 	"created_at":     "2013-08-24",
 	"updated_at":     "2015-08-24",
-	"tags":           ["string"]
+	"tags":           ["string"],
+	"timezone":          "America/New_York",
+	"pauseAllChecks":    true,
+	"silenceAlertsTags": ["string"],
+	"silenceAllAlerts":  false
 }

--- a/types.go
+++ b/types.go
@@ -1907,8 +1907,27 @@ type MaintenanceWindow struct {
 	RepeatUnit     string   `json:"repeatUnit,omitempty"`
 	RepeatEndsAt   string   `json:"repeatEndsAt,omitempty"`
 	Tags           []string `json:"tags,omitempty"`
-	CreatedAt      string   `json:"created_at"`
-	UpdatedAt      string   `json:"updated_at"`
+
+	// Timezone is the named IANA time zone used for recurring maintenance
+	// scheduling, e.g. "America/New_York". UTC offset identifiers such as
+	// "+05:00" are not accepted. Empty means UTC.
+	Timezone string `json:"timezone,omitempty"`
+
+	// PauseAllChecks pauses every check in the account regardless of Tags.
+	// A pointer so that an explicit false is sent rather than omitted.
+	PauseAllChecks *bool `json:"pauseAllChecks,omitempty"`
+
+	// SilenceAlertsTags selects which checks have their alerts silenced.
+	// Ignored when SilenceAllAlerts is true.
+	SilenceAlertsTags []string `json:"silenceAlertsTags,omitempty"`
+
+	// SilenceAllAlerts silences alerts for every check in the account,
+	// overriding SilenceAlertsTags. A pointer so that an explicit false is
+	// sent rather than omitted.
+	SilenceAllAlerts *bool `json:"silenceAllAlerts,omitempty"`
+
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
 }
 
 // PrivateLocation defines a type for a private location.


### PR DESCRIPTION
**Adds `Timezone`, `PauseAllChecks`, `SilenceAlertsTags` and `SilenceAllAlerts` to `MaintenanceWindow`** — all four already exist on the public API and the CLI deploy schema, but had no representation here.

**Both booleans are `*bool` on purpose.** A plain `bool` with `omitempty` is write-once: `false` is treated as empty and dropped from the payload, so users could enable the scope and never disable it. The test sets pause `true` and silence `false` specifically so the explicit `false` has to survive the round-trip.

**`Timezone` is a plain string** — the backend accepts `"UTC"` as an explicit reset, matching the existing `RepeatEndsAt` treatment.

**Unblocks** the matching terraform-provider-checkly change, which is held in draft until this is released.